### PR TITLE
68 user page card functionality

### DIFF
--- a/client/src/components/user-directory/UserDirectoryPage.jsx
+++ b/client/src/components/user-directory/UserDirectoryPage.jsx
@@ -16,7 +16,6 @@ import {
 import { CustomCard } from "@/components/common/CustomCard";
 import { Navbar } from "@/components/layout/Navbar";
 import { BackendContext } from "@/contexts/BackendContext";
-import InputMask from "react-input-mask";
 
 import UserTable from "./UserTable";
 
@@ -24,47 +23,28 @@ export const UserDirectory = () => {
   const { backend } = useContext(BackendContext);
   const [users, setUsers] = useState([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [cardValues, setCardValues] = useState({
-    total: 0,
-    managers: 0,
-    staff: 0,
-    viewers: 0,
-  })
-  // fetching users
+  const [userStats, setUserStats] = useState({});
+
   useEffect(() => {
-    const fetchUsers = async () => {
+    // Fetches users and user stats in parallel
+    const fetchUserInfo = async () => {
       try {
-        const { data } = await backend.get("/users-js");
-        setUsers(data);
-        let total = 0; 
-        let managers = 0; 
-        let staff = 0; 
-        let viewers = 0;
-        for (const user of data) {
-          total++;
-          if (user.role == "master" || user.role == "ccm") {
-            managers++;
-          } else if (user.role == "ccs") {
-            staff++;
-          } else if (user.role == "viewer") {
-            viewers++;
-          }
-          setCardValues({
-            total: total, 
-            managers: managers,
-            staff: staff, 
-            viewers: viewers,
-          });
-        }
+        const [usersRes, statsRes] = await Promise.all([
+          backend.get("/users-js"),
+          backend.get("/users/stats"),
+        ]);
+
+        setUsers(usersRes.data);
+        setUserStats(statsRes.data);
       } catch (err) {
         console.error(
-          "couldn't fetch users in components/UserDirectoryPage.jsx",
+          "couldn't fetch user info in components/UserDirectoryPage.jsx",
           err
         );
       }
     };
 
-    fetchUsers();
+    fetchUserInfo();
   }, [backend]);
 
   // table delete
@@ -188,28 +168,20 @@ export const UserDirectory = () => {
         >
           <CustomCard
             title="Total Users"
-            body={cardValues.total}
+            body={userStats.total}
             height="12rem"
             width="14rem"
           />
-          <CustomCard
-            title="Managers"
-            body={cardValues.managers}
-            height="12rem"
-            width="14rem"
-          />
-          <CustomCard
-            title="Staff"
-            body={cardValues.staff}
-            height="12rem"
-            width="14rem"
-          />
-          <CustomCard
-            title="Viewers"
-            body={cardValues.viewers}
-            height="12rem"
-            width="14rem"
-          />
+          {userStats.byRole &&
+            userStats.byRole.map((userStat) => (
+              <CustomCard
+                key={userStat.role}
+                title={userStat.role}
+                body={userStat.count}
+                height="12rem"
+                width="14rem"
+              />
+            ))}
         </HStack>
       </Box>
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -6,12 +6,57 @@ import { Router } from "express";
 
 export const usersRouter = Router();
 
+const ROLE_MAP = {
+  master: "Managers",
+  ccm: "Managers",
+  ccs: "Staff",
+  viewer: "Viewers",
+};
+
+const ROLE_ORDER = ["Managers", "Staff", "Viewers"];
+
 // Get all users
 usersRouter.get("/", async (req, res) => {
   try {
     const users = await db.query(`SELECT * FROM users ORDER BY id ASC`);
 
     res.status(200).json(keysToCamel(users));
+  } catch (err) {
+    res.status(400).send(err.message);
+  }
+});
+
+// Get statistics of all users
+usersRouter.get("/stats", async (req, res) => {
+  try {
+    const [roleCounts, totalCount] = await db.multi(`
+      SELECT role, COUNT(*)::int AS count
+      FROM users
+      GROUP BY role;
+
+      SELECT COUNT(*)::int AS total
+      FROM users;
+    `);
+
+    if (!roleCounts || !totalCount) {
+      return res.status(404).send("User stats not found");
+    }
+
+    const aggregated = {};
+    roleCounts.forEach(({ role, count }) => {
+      const displayRole = ROLE_MAP[role] || role;
+      aggregated[displayRole] = (aggregated[displayRole] || 0) + count;
+    });
+
+    const byRole = ROLE_ORDER.map((role) => ({
+      role,
+      count: aggregated[role] || 0,
+    }));
+
+    res.status(200).json({
+      total: totalCount[0].total,
+      byRole,
+    });
   } catch (err) {
     res.status(400).send(err.message);
   }


### PR DESCRIPTION
## Description
- Creates a new route `/users/stats` to fetch user statistics
- Groups user counts by role in backend (lowk cursed but idk how to make impl cleaner)
- Displays user statistics in the cards in the user directory page.

## Screenshots/Media
<img width="1276" height="751" alt="image" src="https://github.com/user-attachments/assets/0be92db5-909b-4cd7-b7a4-db4d624c53d9" />

## Issues
Closes #68 

## Additional Notes
Regarding the implementation of counting user roles, a simpler alternative may be to loop the user data and count the role numbers that way in just the frontend. Although aggregation in the DB is faster in practice, we already need to fetch all the user data for the table anyway, so the main cost of reading all rows in the DB is done anyway. Just something we were thinking about :)