### PR TITLE
Navigation bar role logic adjustment

### DIFF
--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -65,7 +65,7 @@ export const Navbar = () => {
           Provider Directory
         </Link>
 
-        {role === "master" && role === "ccm" ? (
+        {role === "master" || role === "ccm" ? (
           <>
             <Link
               as={NavLink}


### PR DESCRIPTION
## Description
adjusted navbar logic to show extra tabs only if ccm or master are true rather than when viewer and ccs is false

## Screenshots/Media
<img width="1052" height="157" alt="image" src="https://github.com/user-attachments/assets/33576e24-1fa4-4398-baf0-d308a72daa2f" />

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->
