### PR TITLE
147 fixed table heights

### DIFF
--- a/client/src/components/provider-directory/ProviderTable.jsx
+++ b/client/src/components/provider-directory/ProviderTable.jsx
@@ -78,7 +78,6 @@ export default function ProviderTable({
     const columns = sortedCategories.map((cat) => (
       <Th
         key={cat.name}
-        fontSize="sm"
         fontWeight="bold"
         color="#2D3748"
       >

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -182,6 +182,7 @@ const QuotaTable = ({ rows, loading, onRowsUpdate }) => {
         <Thead bg="#EBEBEB"
         position="sticky"
         top={0}
+        h="60px"
         zIndex={1}>
           <Tr>
             <Th width="20%">Providers</Th>

--- a/client/src/components/user-directory/UserTable.jsx
+++ b/client/src/components/user-directory/UserTable.jsx
@@ -112,6 +112,7 @@ export default function UserTable({
           <Thead bg="#EBEBEB"
           position="sticky"
           top={0}
+          h="60px"
           zIndex={1}>
             <Tr>
               <Th>Users</Th>

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -90,6 +90,7 @@ const VersionLogTable = ({ loading, logs }) => {
             bg="#EBEBEB"
             position="sticky"
             top={0}
+            h="60px"
             zIndex={1}
           >
             <Tr>


### PR DESCRIPTION
## Description

- Made tables fixed heights and scrollable
- Made column headers fixed and matched to Midfi
- Table headers were originally black with light opacity, changed to solid color so table data is not seen through header)

## Screenshots/Media

<img width="1461" height="721" alt="Screenshot 2026-03-04 at 11 59 07 PM" src="https://github.com/user-attachments/assets/c3211586-6061-4137-bdff-868e52a4cd9f" />

<img width="1512" height="748" alt="Screenshot 2026-03-04 at 11 59 22 PM" src="https://github.com/user-attachments/assets/cc2f0976-cbfc-4e8a-a7c1-f2ffd2557fb5" />

## Issues

Closes #147 

<!-- [Optional]
## Additional Notes
-->
