### PR TITLE
#170 Updated navbar to match Hi-Fi, updated calendar card to match Hi-Fi (…

### DIFF
--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -70,9 +70,12 @@ const CalendarCard = ({ value, onChange }) => {
   });
 
   const today = new Date();
-  const displayValue = value
-    ? new Date(value + "T00:00:00").toLocaleDateString("en-US")
-    : "Select date";
+  const todayStr = today.toLocaleDateString("en-CA");
+  const displayValue = value === todayStr
+    ? "Today"
+    : value
+      ? new Date(value + "T00:00:00").toLocaleDateString("en-US")
+      : "Select date";
 
   return (
     <Popover
@@ -86,17 +89,19 @@ const CalendarCard = ({ value, onChange }) => {
           variant="outline"
           rightIcon={<ChevronDownIcon />}
           onClick={handleOpen}
-          h={{ base: "56px", md: "64px" }}
-          minW={{ base: "180px", md: "196px" }}
-          px={6}
+          h="45px"
+          w="110px"
+          px={3}
           justifyContent="space-between"
-          fontWeight="400"
-          fontSize={{ base: "16px", md: "18px" }}
-          color="#111111"
-          bg="white"
-          borderRadius="12px"
-          border="1.5px solid"
-          borderColor="#E2E8F0"
+          fontFamily="Lato"
+          fontWeight="500"
+          fontSize="14px"
+          fontStyle="normal"
+          lineHeight="28px"
+          color="#000"
+          bg="var(--white, #FFF)"
+          borderRadius="4px"
+          border="0.84px solid #E3E3E3"
           _hover={{ bg: "white", borderColor: "#CBD5E0" }}
           _active={{ bg: "white" }}
         >

--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -86,9 +86,19 @@ const CalendarCard = ({ value, onChange }) => {
           variant="outline"
           rightIcon={<ChevronDownIcon />}
           onClick={handleOpen}
-          fontWeight="normal"
-          fontSize="sm"
-          borderRadius="md"
+          h={{ base: "56px", md: "64px" }}
+          minW={{ base: "180px", md: "196px" }}
+          px={6}
+          justifyContent="space-between"
+          fontWeight="400"
+          fontSize={{ base: "16px", md: "18px" }}
+          color="#111111"
+          bg="white"
+          borderRadius="12px"
+          border="1.5px solid"
+          borderColor="#E2E8F0"
+          _hover={{ bg: "white", borderColor: "#CBD5E0" }}
+          _active={{ bg: "white" }}
         >
           {displayValue}
         </Button>

--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
+import { ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -25,6 +25,12 @@ const CalendarCard = ({ value, onChange }) => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
   });
+
+  useEffect(() => {
+    const d = value ? new Date(value + "T00:00:00") : new Date();
+    setTempDate(d);
+    setViewMonth(new Date(d.getFullYear(), d.getMonth(), 1));
+  }, [value]);
 
   const handleOpen = () => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
@@ -58,15 +64,14 @@ const CalendarCard = ({ value, onChange }) => {
   const firstDay = new Date(year, month, 1).getDay();
   const daysInMonth = new Date(year, month + 1, 0).getDate();
 
-  const monthLabel = viewMonth.toLocaleString("default", { month: "long", year: "numeric" });
+  const monthLabel = viewMonth.toLocaleString("default", {
+    month: "long",
+    year: "numeric",
+  });
 
   const today = new Date();
   const displayValue = value
-    ? new Date(value + "T00:00:00").toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      })
+    ? new Date(value + "T00:00:00").toLocaleDateString("en-US")
     : "Select date";
 
   return (
@@ -79,7 +84,7 @@ const CalendarCard = ({ value, onChange }) => {
       <PopoverTrigger>
         <Button
           variant="outline"
-          leftIcon={<CalendarIcon />}
+          rightIcon={<ChevronDownIcon />}
           onClick={handleOpen}
           fontWeight="normal"
           fontSize="sm"
@@ -97,7 +102,6 @@ const CalendarCard = ({ value, onChange }) => {
         p={0}
       >
         <PopoverBody p={4}>
-          {/* Month navigation */}
           <Flex
             justify="space-between"
             align="center"
@@ -127,7 +131,6 @@ const CalendarCard = ({ value, onChange }) => {
             />
           </Flex>
 
-          {/* Day-of-week headers */}
           <Grid
             templateColumns="repeat(7, 1fr)"
             mb={1}
@@ -146,11 +149,11 @@ const CalendarCard = ({ value, onChange }) => {
             ))}
           </Grid>
 
-          {/* Day cells */}
           <Grid templateColumns="repeat(7, 1fr)">
             {Array.from({ length: firstDay }).map((_, i) => (
               <Box key={`empty-${i}`} />
             ))}
+
             {Array.from({ length: daysInMonth }).map((_, i) => {
               const day = i + 1;
               const isSelected =
@@ -183,7 +186,6 @@ const CalendarCard = ({ value, onChange }) => {
             })}
           </Grid>
 
-          {/* Cancel / Apply */}
           <Flex
             mt={4}
             gap={2}

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -22,27 +22,27 @@ export const Navbar = () => {
   const isSettingsActive = useIsActive("/settings");
 
   const getLinkProps = (isActive) => ({
-    color: isActive ? "#1f4672" : "#111111",
+    color: isActive ? "#113D64" : "#000",
+    fontFamily: "Lato",
+    fontSize: "16px",
+    fontStyle: "normal",
+    fontWeight: isActive ? "700" : "400",
+    lineHeight: "normal",
     px: 2,
     py: 1,
     borderRadius: "md",
-    fontSize: { base: "12px", sm: "16px", md: "18px" },
-
-    fontWeight: isActive ? "700" : "400",
     textDecoration: "none",
     whiteSpace: "nowrap",
     _hover: {
-      color: "#1f4672",
       textDecoration: "none",
-    },
-    _active: {
-      color: "#1f4672",
+      color: "#113D64",
     },
   });
 
   return (
     <Flex
       w="100%"
+      h="90px"
       align="center"
       justify="flex-end"
       gap={{ base: 4, md: 8 }}

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Link } from "@chakra-ui/react";
+import { Flex, Link } from "@chakra-ui/react";
 
 import { useAuthContext } from "@/contexts/hooks/useAuthContext";
 import { useUserContext } from "@/contexts/hooks/useUserContext";
@@ -14,7 +14,7 @@ export const Navbar = () => {
   const { role, loading } = useUserContext();
 
   const savedQuotaDate = sessionStorage.getItem("quotaDate") || "";
-  
+
   const isQuotaActive = useIsActive("/quota-tracking");
   const isProviderActive = useIsActive("/provider-directory");
   const isUserActive = useIsActive("/user-directory");
@@ -22,100 +22,78 @@ export const Navbar = () => {
   const isSettingsActive = useIsActive("/settings");
 
   const getLinkProps = (isActive) => ({
-    color: "white",
+    color: isActive ? "#1f4672" : "#111111",
     px: 2,
     py: 1,
     borderRadius: "md",
-    fontSize: { base: "8px", sm: "14px" },
+    // fontSize: { base: "12px", sm: "16px", md: "18px" },
+    fontSize: "18px",
+
     fontWeight: isActive ? "700" : "400",
     textDecoration: "none",
+    whiteSpace: "nowrap",
     _hover: {
-      textShadow: "0 0 0.5px white, 0 0 0.5px white",
+      color: "#1f4672",
       textDecoration: "none",
     },
     _active: {
-      fontWeight: "400",
+      color: "#1f4672",
     },
   });
 
   return (
-    <>
-      <Box
-        position="fixed"
-        bottom="0"
-        left="0"
-        right="0"
-        h="200px"
-        zIndex={9}
-        pointerEvents="none"
-        bgGradient="linear(to-t, white, transparent)"
-      />
-      <Flex
-        position="fixed"
-        bottom="5vh"
-        left="50%"
-        transform="translateX(-50%)"
-        bg="black"
-        w={{ base: "90%", md: "56%" }}
-        h="60px"
-        borderRadius="16px"
-        align="center"
-        justify="space-evenly"
-        px={4}
-        zIndex={10}
+    <Flex
+      w="100%"
+      align="center"
+      justify="flex-end"
+      gap={{ base: 4, md: 8 }}
+      flexWrap="wrap"
+    >
+      <Link
+        as={NavLink}
+        to={`/quota-tracking/${savedQuotaDate}`}
+        {...getLinkProps(isQuotaActive)}
       >
-        <Flex
-          gap="3"
-          width="100%"
-          justify="space-evenly"
-        >
+        Quota Tracking
+      </Link>
+
+      <Link
+        as={NavLink}
+        to="/provider-directory"
+        {...getLinkProps(isProviderActive)}
+      >
+        Provider Directory
+      </Link>
+
+      {role === "master" || role === "ccm" ? (
+        <>
           <Link
             as={NavLink}
-            to={`/quota-tracking/${savedQuotaDate}`}
-            {...getLinkProps(isQuotaActive)}
+            to="/user-directory"
+            {...getLinkProps(isUserActive)}
           >
-            Quota Tracking
+            User Directory
           </Link>
-
           <Link
             as={NavLink}
-            to="/provider-directory"
-            {...getLinkProps(isProviderActive)}
+            to="/version-log"
+            {...getLinkProps(isVersionActive)}
           >
-            Provider Directory
+            Audit Log
           </Link>
+        </>
+      ) : (
+        <></>
+      )}
 
-          {role === "master" || role === "ccm" ? (
-            <>
-              <Link
-                as={NavLink}
-                to="/user-directory"
-                {...getLinkProps(isUserActive)}
-              >
-                User Directory
-              </Link>
-              <Link
-                as={NavLink}
-                to="/version-log"
-                {...getLinkProps(isVersionActive)}
-              >
-                Version Log
-              </Link>
-            </>
-          ) : (
-            <></>
-          )}
-
-          <Link
-            as={NavLink}
-            to="/settings"
-            {...getLinkProps(isSettingsActive)}
-          >
-            Settings
-          </Link>
-        </Flex>
-      </Flex>
-    </>
+      <Link
+        as={NavLink}
+        to="/settings"
+        {...getLinkProps(isSettingsActive)}
+      >
+        Settings
+      </Link>
+    </Flex>
   );
 };
 

--- a/client/src/components/layout/Navbar.jsx
+++ b/client/src/components/layout/Navbar.jsx
@@ -26,8 +26,7 @@ export const Navbar = () => {
     px: 2,
     py: 1,
     borderRadius: "md",
-    // fontSize: { base: "12px", sm: "16px", md: "18px" },
-    fontSize: "18px",
+    fontSize: { base: "12px", sm: "16px", md: "18px" },
 
     fontWeight: isActive ? "700" : "400",
     textDecoration: "none",

--- a/client/src/components/layout/layout.jsx
+++ b/client/src/components/layout/layout.jsx
@@ -14,15 +14,15 @@ const Layout = () => {
                 width="100%"
                 padding="9px 40px"
                 alignItems="center"
-                gap="452px"
+                justifyContent="space-between"
             >
                 <Image
                     src="clchc-logo.svg"
                     width="250px"
                     height="94px"
-                    padding-right="40px"
-                    padding-top="9px"
-                    padding-bottom="9px"
+                    pr="40px"
+                    pt="9px"
+                    pb="9px"
                 />
                 <Navbar/>
             </Box>

--- a/client/src/components/layout/layout.jsx
+++ b/client/src/components/layout/layout.jsx
@@ -1,12 +1,31 @@
-import { Box } from "@chakra-ui/react"
-
+import { Box, Image } from "@chakra-ui/react"
+import React from "react";
 import { Outlet } from "react-router-dom";
 import Navbar from "./Navbar";
 
 const Layout = () => {
     return (
-        <Box minH="100vh" paddingBottom="calc(5vh + 80px)">
-            <Navbar/>
+        <Box
+            minH="100vh"
+            paddingBottom="calc(5vh + 80px)"
+        >
+            <Box
+                display="inline-flex"
+                width="100%"
+                padding="9px 40px"
+                alignItems="center"
+                gap="452px"
+            >
+                <Image
+                    src="clchc-logo.svg"
+                    width="250px"
+                    height="94px"
+                    padding-right="40px"
+                    padding-top="9px"
+                    padding-bottom="9px"
+                />
+                <Navbar/>
+            </Box>
             <Outlet/>
         </Box>
     );

--- a/client/src/components/provider-directory/ProviderDirectoryPage.jsx
+++ b/client/src/components/provider-directory/ProviderDirectoryPage.jsx
@@ -93,12 +93,12 @@ export const ProviderDirectoryPage = () => {
   return (
     <Box p={6}>
       <Box mb={5}>
-        <PageHeader
+        {/* <PageHeader
           title="Provider Directory"
           subheading="All current active providers in network"
           role={role}
           isLoading={roleLoading}
-        />
+        /> */}
       </Box>
 
       {role === "ccm" || role === "master" ? (
@@ -185,6 +185,7 @@ export const ProviderDirectoryPage = () => {
             <Input
               placeholder="Search Providers"
               borderRadius="md"
+              h="45px"
               onChange={handleChange}
             />
           </InputGroup>
@@ -229,7 +230,6 @@ export const ProviderDirectoryPage = () => {
         onClose={onProviderDrawerClose}
         onSaved={handleDrawerSaved}
       />
-      <Navbar />
     </Box>
   );
 };

--- a/client/src/components/version-log/VersionLogPage.jsx
+++ b/client/src/components/version-log/VersionLogPage.jsx
@@ -2,16 +2,14 @@ import { useState, useEffect } from "react";
 import { SearchIcon } from "@chakra-ui/icons";
 import {
   Box,
-  Flex,
+  Badge,
+  Heading,
   Input,
   InputGroup,
   InputLeftElement,
-  Stack,
   HStack,
 } from "@chakra-ui/react";
 
-import { PageHeader } from "@/components/common/PageHeader";
-import Navbar from "@/components/layout/Navbar";
 import VersionLogTable from "@/components/version-log/VersionLogTable";
 import { useVersionLogs } from "@/contexts/hooks/data-fetching/useVersionLogs";
 import { useUserContext } from "@/contexts/hooks/useUserContext";
@@ -21,29 +19,26 @@ import CalendarCard from "../common/CalendarCard";
 
 
 export const VersionLogPage = () => {
-  // const [logs, setLogs] = useState([]);
-  // const { backend } = useBackendContext();
   const navigate = useNavigate();
-  const { dateParam } = useParams();
+  const { date } = useParams();
   const [inputValue, setInputValue] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const today = new Date().toLocaleDateString("en-CA");
   const [selectedDate, setSelectedDate] = useState(
-    dateParam || sessionStorage.getItem("logDate") || today
+    date || sessionStorage.getItem("logDate") || today
   );
   const debouncedSearchQuery = useDebounce(
     (value) => setSearchQuery(value),
     300
   );
-  const { role, loading: roleLoading } = useUserContext();
-  // const [loading, setLoading] = useState(true);
+  const { role } = useUserContext();
 
   useEffect(() => {
-    if (dateParam && dateParam !== selectedDate) {
-      setSelectedDate(dateParam);
-      sessionStorage.setItem("logDate", dateParam);
+    if (date && date !== selectedDate) {
+      setSelectedDate(date);
+      sessionStorage.setItem("logDate", date);
     }
-  }, [dateParam]);
+  }, [date, selectedDate]);
 
   useEffect(() => {
     sessionStorage.setItem("logDate", selectedDate);
@@ -56,7 +51,6 @@ export const VersionLogPage = () => {
     q: searchQuery,
   });
 
-  // handleChange
   const handleChange = (e) => {
     setInputValue(e.target.value);
     debouncedSearchQuery(e.target.value);
@@ -69,32 +63,68 @@ export const VersionLogPage = () => {
 
   return (
     <Box
-      p={6}
-      maxW="1200px"
+      px={{ base: 4, md: 10 }}
+      py={{ base: 4, md: 6 }}
+      maxW="1440px"
       mx="auto"
     >
-      <Flex
-        justify="space-between"
-        align="flex-start"
+      <HStack
+        spacing={3}
+        align="center"
         mb={6}
       >
-        <Box
-          flex="1"
-          display="flex"
-          justifyContent="flex-end"
+        <Heading
+          as="h1"
+          size="lg"
+          fontWeight="500"
+          color="#111111"
         >
-        </Box>
-      </Flex>
+          Audit Log
+        </Heading>
+        {role && (
+          <Badge
+            bg="#5B4761"
+            color="white"
+            borderRadius="8px"
+            px={3}
+            py={1}
+            fontSize="18px"
+            fontWeight="500"
+            textTransform="capitalize"
+          >
+            {role}
+          </Badge>
+        )}
+      </HStack>
 
-      <HStack paddingBottom="12px">
-        <InputGroup paddingRight="15px">
+      <HStack
+        spacing={{ base: 3, md: 6 }}
+        align="stretch"
+        mb={3}
+      >
+        <InputGroup flex="1">
           <InputLeftElement pointerEvents="none">
-            <SearchIcon color="gray.400" />
+            <SearchIcon
+              color="#111111"
+              boxSize={5}
+            />
           </InputLeftElement>
           <Input
-            placeholder="Dr. Sarah Chen"
-            borderRadius="md"
-            value={inputValue}  
+            placeholder="Search Providers"
+            h={{ base: "56px", md: "64px" }}
+            borderRadius="12px"
+            border="1.5px solid"
+            borderColor="#E2E8F0"
+            bg="white"
+            fontSize={{ base: "16px", md: "18px" }}
+            color="#2D3748"
+            _placeholder={{ color: "#A0AEC0" }}
+            _hover={{ borderColor: "#CBD5E0" }}
+            _focusVisible={{
+              borderColor: "#A0AEC0",
+              boxShadow: "none",
+            }}
+            value={inputValue}
             onChange={handleChange}
           />
         </InputGroup>

--- a/client/src/components/version-log/VersionLogPage.jsx
+++ b/client/src/components/version-log/VersionLogPage.jsx
@@ -7,6 +7,7 @@ import {
   InputGroup,
   InputLeftElement,
   Stack,
+  HStack,
 } from "@chakra-ui/react";
 
 import { PageHeader } from "@/components/common/PageHeader";
@@ -65,7 +66,7 @@ export const VersionLogPage = () => {
     setSelectedDate(newDate);
     navigate(`/version-log/${newDate}`);
   };
-  // console.log("Selected Date:", selectedDate);
+
   return (
     <Box
       p={6}
@@ -77,43 +78,37 @@ export const VersionLogPage = () => {
         align="flex-start"
         mb={6}
       >
-        <PageHeader
-          title="Version Log"
-          subheading="View action history over given day"
-          role={role}
-          isLoading={roleLoading}
-        />
         <Box
           flex="1"
           display="flex"
           justifyContent="flex-end"
         >
-          <CalendarCard
-            value={selectedDate}
-            onChange={handleDateChange}
-          />
         </Box>
       </Flex>
 
-      <Stack gap={2}>
-        <InputGroup>
+      <HStack paddingBottom="12px">
+        <InputGroup paddingRight="15px">
           <InputLeftElement pointerEvents="none">
             <SearchIcon color="gray.400" />
           </InputLeftElement>
           <Input
-            placeholder="Search Version Log"
+            placeholder="Dr. Sarah Chen"
             borderRadius="md"
             value={inputValue}  
             onChange={handleChange}
           />
         </InputGroup>
-        <VersionLogTable
-          loading={isLoading}
-          logs={logs}
-          selectedDate={selectedDate}
+
+        <CalendarCard
+          value={selectedDate}
+          onChange={handleDateChange}
         />
-      </Stack>
-      <Navbar />
+      </HStack>
+      <VersionLogTable
+        loading={isLoading}
+        logs={logs}
+        selectedDate={selectedDate}
+      />
     </Box>
   );
 };

--- a/client/src/components/version-log/VersionLogPage.jsx
+++ b/client/src/components/version-log/VersionLogPage.jsx
@@ -68,7 +68,7 @@ export const VersionLogPage = () => {
       maxW="1440px"
       mx="auto"
     >
-      <HStack
+      {/* <HStack
         spacing={3}
         align="center"
         mb={6}
@@ -95,7 +95,7 @@ export const VersionLogPage = () => {
             {role}
           </Badge>
         )}
-      </HStack>
+      </HStack> */}
 
       <HStack
         spacing={{ base: 3, md: 6 }}
@@ -104,26 +104,12 @@ export const VersionLogPage = () => {
       >
         <InputGroup flex="1">
           <InputLeftElement pointerEvents="none">
-            <SearchIcon
-              color="#111111"
-              boxSize={5}
-            />
+            <SearchIcon color="gray.400" />
           </InputLeftElement>
           <Input
             placeholder="Search Providers"
-            h={{ base: "56px", md: "64px" }}
-            borderRadius="12px"
-            border="1.5px solid"
-            borderColor="#E2E8F0"
-            bg="white"
-            fontSize={{ base: "16px", md: "18px" }}
-            color="#2D3748"
-            _placeholder={{ color: "#A0AEC0" }}
-            _hover={{ borderColor: "#CBD5E0" }}
-            _focusVisible={{
-              borderColor: "#A0AEC0",
-              boxShadow: "none",
-            }}
+            borderRadius="md"
+            h="45px"
             value={inputValue}
             onChange={handleChange}
           />

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -148,6 +148,7 @@ const VersionLogTable = ({ loading, logs }) => {
                 const formattedDate = logDate.toLocaleDateString("en-US", {
                   month: "2-digit",
                   day: "2-digit",
+                  year: "numeric"
                 });
 
                 const formattedTime = logDate

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -13,8 +13,9 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-const CELL_BORDER_COLOR = "#E2E8F0";
-const HEADER_BG = "#CBD7E8";
+const CELL_BORDER_COLOR = "#E7EDF5";
+const VERTICAL_BORDER_COLOR = "#EDF2F7";
+const HEADER_BG = "#C7D5E8";
 const COLUMN_WIDTH = "25%";
 
 const SkeletonRows = () => {
@@ -29,14 +30,20 @@ const SkeletonRows = () => {
           <Td
             w={COLUMN_WIDTH}
             py="18px"
+            px="26px"
             borderColor={CELL_BORDER_COLOR}
+            borderRight="1px solid"
+            borderRightColor={VERTICAL_BORDER_COLOR}
           >
             <Skeleton height="24px" />
           </Td>
           <Td
             w={COLUMN_WIDTH}
             py="18px"
+            px="26px"
             borderColor={CELL_BORDER_COLOR}
+            borderRight="1px solid"
+            borderRightColor={VERTICAL_BORDER_COLOR}
           >
             <Skeleton
               height="24px"
@@ -46,7 +53,10 @@ const SkeletonRows = () => {
           <Td
             w={COLUMN_WIDTH}
             py="18px"
+            px="26px"
             borderColor={CELL_BORDER_COLOR}
+            borderRight="1px solid"
+            borderRightColor={VERTICAL_BORDER_COLOR}
           >
             <Skeleton
               height="24px"
@@ -70,26 +80,31 @@ const SkeletonRows = () => {
 
 const headerCellProps = () => ({
   w: COLUMN_WIDTH,
-  h: "48px",
-  px: "28px",
+  h: "44px",
+  px: "26px",
   py: "12px",
-  color: "#4A5568",
-  fontSize: "16px",
+  color: "#1f4672",
+  fontSize: "15px",
   fontWeight: "700",
-  textTransform: "none",
-  borderBottom: "1.5px solid",
+  letterSpacing: "0.06em",
+  textTransform: "uppercase",
+  borderBottom: "1px solid",
+  borderRight: "1px solid",
   borderColor: CELL_BORDER_COLOR,
+  borderRightColor: VERTICAL_BORDER_COLOR,
   bg: HEADER_BG,
 });
 
-const bodyCellProps = () => ({
+const bodyCellProps = (withRightBorder = true) => ({
   w: COLUMN_WIDTH,
-  px: "28px",
-  py: "18px",
-  fontSize: "16px",
+  px: "26px",
+  py: "30px",
+  fontSize: "15px",
   color: "#2D3748",
-  borderBottom: "1.5px solid",
+  borderBottom: "1px solid",
   borderColor: CELL_BORDER_COLOR,
+  borderRight: withRightBorder ? "1px solid" : "none",
+  borderRightColor: VERTICAL_BORDER_COLOR,
   verticalAlign: "middle",
 });
 
@@ -102,11 +117,11 @@ const VersionLogTable = ({ loading, logs }) => {
       <TableContainer
         w="100%"
         maxW="1360px"
-        minH="818px"
+        minH="720px"
         borderRadius="6px"
-        border="1.5px solid"
+        border="1px solid"
         borderColor={CELL_BORDER_COLOR}
-        p="12px"
+        p="0"
         bg="white"
         overflowX="auto"
         overflowY="auto"
@@ -120,7 +135,12 @@ const VersionLogTable = ({ loading, logs }) => {
               <Th {...headerCellProps()}>Editor</Th>
               <Th {...headerCellProps()}>Action</Th>
               <Th {...headerCellProps()}>Date & Time</Th>
-              <Th {...headerCellProps()}>Provider</Th>
+              <Th
+                {...headerCellProps()}
+                borderRight="none"
+              >
+                Provider
+              </Th>
             </Tr>
           </Thead>
 
@@ -131,8 +151,8 @@ const VersionLogTable = ({ loading, logs }) => {
                   colSpan={4}
                   py="40px"
                   textAlign="center"
-                  color="gray.500"
-                  fontSize="16px"
+                  color="#718096"
+                  fontSize="15px"
                 >
                   No version history available
                 </Td>
@@ -142,7 +162,7 @@ const VersionLogTable = ({ loading, logs }) => {
             {loading ? (
               <SkeletonRows />
             ) : (
-              logs.map((entry) => {
+              logs.map((entry, index) => {
                 const logDate = new Date(entry.timestamp);
 
                 const formattedDate = logDate.toLocaleDateString("en-US", {
@@ -161,6 +181,7 @@ const VersionLogTable = ({ loading, logs }) => {
                 return (
                   <Tr
                     key={entry.id}
+                    bg={index % 2 === 0 ? "white" : "#FAFBFC"}
                     _hover={{ bg: "#F8FAFC" }}
                   >
                     <Td {...bodyCellProps()}>
@@ -173,8 +194,8 @@ const VersionLogTable = ({ loading, logs }) => {
                           Quota{" "}
                           <Text
                             as="span"
-                            color="#38A169"
-                            fontWeight="500"
+                            color="#2F9E5B"
+                            fontWeight="600"
                           >
                             +{entry.delta}
                           </Text>
@@ -186,8 +207,8 @@ const VersionLogTable = ({ loading, logs }) => {
                           Quota{" "}
                           <Text
                             as="span"
-                            color="#E53E3E"
-                            fontWeight="500"
+                            color="#D64545"
+                            fontWeight="600"
                           >
                             {entry.delta}
                           </Text>
@@ -199,7 +220,7 @@ const VersionLogTable = ({ loading, logs }) => {
                       {formattedDate} {formattedTime}
                     </Td>
 
-                    <Td {...bodyCellProps()}>
+                    <Td {...bodyCellProps(false)}>
                       {entry.providerData["Name"]}
                     </Td>
                   </Tr>

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -13,100 +13,50 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
-const CELL_BORDER_COLOR = "#E7EDF5";
-const VERTICAL_BORDER_COLOR = "#EDF2F7";
-const HEADER_BG = "#C7D5E8";
-const COLUMN_WIDTH = "25%";
-
 const SkeletonRows = () => {
   return (
     <>
       {Array.from({ length: 5 }, (_, i) => (
         <Tr
           key={i}
-          borderBottom="1.5px solid"
-          borderColor={CELL_BORDER_COLOR}
+          borderBottom="1px solid"
+          borderColor="gray.200"
         >
-          <Td
-            w={COLUMN_WIDTH}
-            py="18px"
-            px="26px"
-            borderColor={CELL_BORDER_COLOR}
-            borderRight="1px solid"
-            borderRightColor={VERTICAL_BORDER_COLOR}
-          >
-            <Skeleton height="24px" />
-          </Td>
-          <Td
-            w={COLUMN_WIDTH}
-            py="18px"
-            px="26px"
-            borderColor={CELL_BORDER_COLOR}
-            borderRight="1px solid"
-            borderRightColor={VERTICAL_BORDER_COLOR}
-          >
-            <Skeleton
-              height="24px"
-              width="90px"
-            />
-          </Td>
-          <Td
-            w={COLUMN_WIDTH}
-            py="18px"
-            px="26px"
-            borderColor={CELL_BORDER_COLOR}
-            borderRight="1px solid"
-            borderRightColor={VERTICAL_BORDER_COLOR}
-          >
-            <Skeleton
-              height="24px"
-              width="140px"
-            />
-          </Td>
-          <Td
-            w={COLUMN_WIDTH}
-            py="18px"
-          >
-            <Skeleton
-              height="24px"
-              width="220px"
-            />
-          </Td>
+          {Array.from({ length: 4 }, (_, j) => (
+            <Td
+              key={j}
+              borderRight="1px solid"
+              borderColor="gray.200"
+            >
+              <Skeleton height="40px" />
+            </Td>
+          ))}
         </Tr>
       ))}
     </>
   );
 };
 
-const headerCellProps = () => ({
-  w: COLUMN_WIDTH,
-  h: "44px",
-  px: "26px",
-  py: "12px",
-  color: "#1f4672",
-  fontSize: "15px",
+const thProps = {
+  fontFamily: "Inter",
+  fontSize: "12px",
+  fontStyle: "normal",
   fontWeight: "700",
-  letterSpacing: "0.06em",
-  textTransform: "uppercase",
-  borderBottom: "1px solid",
-  borderRight: "1px solid",
-  borderColor: CELL_BORDER_COLOR,
-  borderRightColor: VERTICAL_BORDER_COLOR,
-  bg: HEADER_BG,
-});
+  lineHeight: "16px",
+  letterSpacing: "0.6px",
+  padding: "15px 25px 15px 25px",
+  backgroundColor: "#C8D4E6",
+  color: "#113D64",
+};
 
-const bodyCellProps = (withRightBorder = true) => ({
-  w: COLUMN_WIDTH,
-  px: "26px",
-  py: "30px",
-  fontSize: "15px",
-  color: "#2D3748",
-  borderBottom: "1px solid",
-  borderColor: CELL_BORDER_COLOR,
-  borderRight: withRightBorder ? "1px solid" : "none",
-  borderRightColor: VERTICAL_BORDER_COLOR,
-  verticalAlign: "middle",
-});
+const tdTextProps = {
+  fontFamily: "Inter",
+  fontSize: "14px",
+  fontStyle: "normal",
+  fontWeight: "400",
+  lineHeight: "22px",
+  color: "#113D64",
+};
 
 const VersionLogTable = ({ loading, logs }) => {
   return (
@@ -115,32 +65,29 @@ const VersionLogTable = ({ loading, logs }) => {
       align="stretch"
     >
       <TableContainer
-        w="100%"
-        maxW="1360px"
-        minH="720px"
-        borderRadius="6px"
         border="1px solid"
-        borderColor={CELL_BORDER_COLOR}
-        p="0"
-        bg="white"
-        overflowX="auto"
+        borderColor="gray.200"
+        borderRadius="lg"
+        maxHeight="60vh"
         overflowY="auto"
       >
         <Table
-          variant="unstyled"
-          sx={{ tableLayout: "fixed" }}
+          sx={{
+            "tbody tr:nth-of-type(even)": { bg: "#F9F9F9" },
+            "tbody tr:nth-of-type(odd)": { bg: "white" },
+          }}
         >
-          <Thead>
+          <Thead
+            position="sticky"
+            top={0}
+            zIndex={1}
+            h="40px"
+          >
             <Tr>
-              <Th {...headerCellProps()}>Editor</Th>
-              <Th {...headerCellProps()}>Action</Th>
-              <Th {...headerCellProps()}>Date & Time</Th>
-              <Th
-                {...headerCellProps()}
-                borderRight="none"
-              >
-                Provider
-              </Th>
+              <Th {...thProps}>Editor</Th>
+              <Th {...thProps}>Action</Th>
+              <Th {...thProps}>Date & Time</Th>
+              <Th {...thProps}>Provider</Th>
             </Tr>
           </Thead>
 
@@ -151,8 +98,9 @@ const VersionLogTable = ({ loading, logs }) => {
                   colSpan={4}
                   py="40px"
                   textAlign="center"
-                  color="#718096"
-                  fontSize="15px"
+                  color="gray.400"
+                  fontFamily="Inter"
+                  fontSize="14px"
                 >
                   No version history available
                 </Td>
@@ -162,13 +110,13 @@ const VersionLogTable = ({ loading, logs }) => {
             {loading ? (
               <SkeletonRows />
             ) : (
-              logs.map((entry, index) => {
+              logs.map((entry) => {
                 const logDate = new Date(entry.timestamp);
 
                 const formattedDate = logDate.toLocaleDateString("en-US", {
                   month: "2-digit",
                   day: "2-digit",
-                  year: "numeric"
+                  year: "numeric",
                 });
 
                 const formattedTime = logDate
@@ -182,16 +130,25 @@ const VersionLogTable = ({ loading, logs }) => {
                 return (
                   <Tr
                     key={entry.id}
-                    bg={index % 2 === 0 ? "white" : "#FAFBFC"}
-                    _hover={{ bg: "#F8FAFC" }}
+                    borderBottom="1px solid"
+                    borderColor="gray.200"
+                    cursor="default"
                   >
-                    <Td {...bodyCellProps()}>
-                      {entry.firstName} {entry.lastName}
+                    <Td
+                      borderRight="1px solid"
+                      borderColor="gray.200"
+                    >
+                      <Text {...tdTextProps}>
+                        {entry.firstName} {entry.lastName}
+                      </Text>
                     </Td>
 
-                    <Td {...bodyCellProps()}>
+                    <Td
+                      borderRight="1px solid"
+                      borderColor="gray.200"
+                    >
                       {entry.action === "increment" && (
-                        <>
+                        <Text {...tdTextProps}>
                           Quota{" "}
                           <Text
                             as="span"
@@ -200,11 +157,10 @@ const VersionLogTable = ({ loading, logs }) => {
                           >
                             +{entry.delta}
                           </Text>
-                        </>
+                        </Text>
                       )}
-
                       {entry.action === "decrement" && (
-                        <>
+                        <Text {...tdTextProps}>
                           Quota{" "}
                           <Text
                             as="span"
@@ -213,16 +169,23 @@ const VersionLogTable = ({ loading, logs }) => {
                           >
                             {entry.delta}
                           </Text>
-                        </>
+                        </Text>
                       )}
                     </Td>
 
-                    <Td {...bodyCellProps()}>
-                      {formattedDate} {formattedTime}
+                    <Td
+                      borderRight="1px solid"
+                      borderColor="gray.200"
+                    >
+                      <Text {...tdTextProps}>
+                        {formattedDate} {formattedTime}
+                      </Text>
                     </Td>
 
-                    <Td {...bodyCellProps(false)}>
-                      {entry.providerData["Name"]}
+                    <Td borderRight="1px solid" borderColor="gray.200">
+                      <Text {...tdTextProps}>
+                        {entry.providerName}
+                      </Text>
                     </Td>
                   </Tr>
                 );

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import {
-  Box,
   Skeleton,
   Table,
   TableContainer,
@@ -14,60 +13,85 @@ import {
   VStack,
 } from "@chakra-ui/react";
 
+const CELL_BORDER_COLOR = "#E2E8F0";
+const HEADER_BG = "#CBD7E8";
+const COLUMN_WIDTH = "25%";
+
 const SkeletonRows = () => {
   return (
     <>
       {Array.from({ length: 5 }, (_, i) => (
-        <Tr key={i}>
-          <Td>
-            <Skeleton height="30px" />
+        <Tr
+          key={i}
+          borderBottom="1.5px solid"
+          borderColor={CELL_BORDER_COLOR}
+        >
+          <Td
+            w={COLUMN_WIDTH}
+            py="18px"
+            borderColor={CELL_BORDER_COLOR}
+          >
+            <Skeleton height="24px" />
           </Td>
-          <Td>
-            <Box
-              display="flex"
-              flexDirection="row"
-              gap={2}
-            >
-              <Skeleton
-                height="30px"
-                width="40%"
-              />
-              <Skeleton
-                height="30px"
-                width="25%"
-              />
-            </Box>
-          </Td>
-          <Td>
-            <Skeleton height="30px" />
-          </Td>
-          <Td>
+          <Td
+            w={COLUMN_WIDTH}
+            py="18px"
+            borderColor={CELL_BORDER_COLOR}
+          >
             <Skeleton
-              height="30px"
-              width="50%"
+              height="24px"
+              width="90px"
             />
           </Td>
-          <Td>
-            <Box
-              display="flex"
-              flexDirection="column"
-              gap="2px"
-            >
-              <Skeleton height="15px" />
-              <Skeleton
-                height="10px"
-                width="80%"
-              />
-            </Box>
+          <Td
+            w={COLUMN_WIDTH}
+            py="18px"
+            borderColor={CELL_BORDER_COLOR}
+          >
+            <Skeleton
+              height="24px"
+              width="140px"
+            />
           </Td>
-          <Td>
-            <Skeleton height="30px" />
+          <Td
+            w={COLUMN_WIDTH}
+            py="18px"
+          >
+            <Skeleton
+              height="24px"
+              width="220px"
+            />
           </Td>
         </Tr>
       ))}
     </>
   );
 };
+
+const headerCellProps = () => ({
+  w: COLUMN_WIDTH,
+  h: "48px",
+  px: "28px",
+  py: "12px",
+  color: "#4A5568",
+  fontSize: "16px",
+  fontWeight: "700",
+  textTransform: "none",
+  borderBottom: "1.5px solid",
+  borderColor: CELL_BORDER_COLOR,
+  bg: HEADER_BG,
+});
+
+const bodyCellProps = () => ({
+  w: COLUMN_WIDTH,
+  px: "28px",
+  py: "18px",
+  fontSize: "16px",
+  color: "#2D3748",
+  borderBottom: "1.5px solid",
+  borderColor: CELL_BORDER_COLOR,
+  verticalAlign: "middle",
+});
 
 const VersionLogTable = ({ loading, logs }) => {
   return (
@@ -76,44 +100,41 @@ const VersionLogTable = ({ loading, logs }) => {
       align="stretch"
     >
       <TableContainer
-        border="1px solid"
-        borderColor="gray.200"
-        borderRadius="lg"
-        maxHeight="60vh"
+        w="100%"
+        maxW="1360px"
+        minH="818px"
+        borderRadius="6px"
+        border="1.5px solid"
+        borderColor={CELL_BORDER_COLOR}
+        p="12px"
+        bg="white"
+        overflowX="auto"
         overflowY="auto"
       >
         <Table
-          size="sm"
+          variant="unstyled"
           sx={{ tableLayout: "fixed" }}
         >
-          <Thead
-            bg="#EBEBEB"
-            position="sticky"
-            top={0}
-            h="60px"
-            zIndex={1}
-          >
+          <Thead>
             <Tr>
-              <Th width="20%">Editor</Th>
-              <Th width="15%">Action</Th>
-              <Th width="15%">Date</Th>
-              <Th width="15%">Time</Th>
-              <Th width="17.5%">Provider</Th>
-              <Th width="17.5%">Quota Created</Th>
+              <Th {...headerCellProps()}>Editor</Th>
+              <Th {...headerCellProps()}>Action</Th>
+              <Th {...headerCellProps()}>Date & Time</Th>
+              <Th {...headerCellProps()}>Provider</Th>
             </Tr>
           </Thead>
 
           <Tbody>
             {!loading && logs.length === 0 && (
               <Tr>
-                <Td colSpan={6}>
-                  <Text
-                    textAlign="center"
-                    py={6}
-                    color="gray.500"
-                  >
-                    No version history available
-                  </Text>
+                <Td
+                  colSpan={4}
+                  py="40px"
+                  textAlign="center"
+                  color="gray.500"
+                  fontSize="16px"
+                >
+                  No version history available
                 </Td>
               </Tr>
             )}
@@ -122,55 +143,51 @@ const VersionLogTable = ({ loading, logs }) => {
               <SkeletonRows />
             ) : (
               logs.map((entry) => {
-                const log_d = new Date(entry.timestamp);
+                const logDate = new Date(entry.timestamp);
 
-                const log_date = log_d.toLocaleDateString("en-US", {
+                const formattedDate = logDate.toLocaleDateString("en-US", {
                   month: "2-digit",
                   day: "2-digit",
-                  year: "numeric",
                 });
 
-                const log_time = log_d.toLocaleTimeString("en-US", {
-                  hour: "2-digit",
-                  minute: "2-digit",
-                  hour12: false,
-                });
-
-                const quota_d = new Date(entry.date);
-
-                const quota_date = quota_d.toLocaleDateString("en-US", {
-                  month: "2-digit",
-                  day: "2-digit",
-                  year: "numeric",
-                });
+                const formattedTime = logDate
+                  .toLocaleTimeString("en-US", {
+                    hour: "numeric",
+                    minute: "2-digit",
+                    hour12: true,
+                  })
+                  .toLowerCase();
 
                 return (
                   <Tr
                     key={entry.id}
-                    _hover={{ bg: "gray.50" }}
+                    _hover={{ bg: "#F8FAFC" }}
                   >
-                    <Td>
+                    <Td {...bodyCellProps()}>
                       {entry.firstName} {entry.lastName}
                     </Td>
 
-                    <Td fontWeight="medium">
+                    <Td {...bodyCellProps()}>
                       {entry.action === "increment" && (
                         <>
                           Quota{" "}
                           <Text
                             as="span"
-                            color="green.500"
+                            color="#38A169"
+                            fontWeight="500"
                           >
                             +{entry.delta}
                           </Text>
                         </>
                       )}
+
                       {entry.action === "decrement" && (
                         <>
                           Quota{" "}
                           <Text
                             as="span"
-                            color="red.500"
+                            color="#E53E3E"
+                            fontWeight="500"
                           >
                             {entry.delta}
                           </Text>
@@ -178,21 +195,13 @@ const VersionLogTable = ({ loading, logs }) => {
                       )}
                     </Td>
 
-                    <Td color="gray.600">{log_date}</Td>
-                    <Td color="gray.600">{log_time}</Td>
-
-                    <Td fontWeight="medium">
-                      {entry.providerData["Name"]}
-                      <Text
-                        fontWeight="normal"
-                        color="gray.500"
-                      >
-                        {entry.providerData["Office Hours"]}
-                      </Text>
-                      {/* TODO: We should really camel case the jsonb data keys. */}
+                    <Td {...bodyCellProps()}>
+                      {formattedDate} {formattedTime}
                     </Td>
 
-                    <Td color="gray.600">{quota_date}</Td>
+                    <Td {...bodyCellProps()}>
+                      {entry.providerData["Name"]}
+                    </Td>
                   </Tr>
                 );
               })

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -9,7 +9,16 @@ const colors = {
   brand: {},
 };
 
-const theme = extendTheme({ colors });
+const theme = extendTheme({
+  colors,
+  styles: {
+    global: {
+      body: {
+        bg: "#F9F9F9",
+      },
+    },
+  },
+});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/server/routes/versionLog.js
+++ b/server/routes/versionLog.js
@@ -54,7 +54,7 @@ versionLogRouter.get("/details", verifyRole("ccm"), async (req, res) => {
         (
           "users".first_name ILIKE $${values.length} OR
           "users".last_name ILIKE $${values.length} OR
-          providers.data->>'Name' ILIKE $${values.length}
+          providers.name ILIKE $${values.length}
         )
       `);
     }
@@ -83,7 +83,7 @@ versionLogRouter.get("/details", verifyRole("ccm"), async (req, res) => {
         quota.end_time AS time,
         "users".first_name,
         "users".last_name,
-        providers.data AS provider_data
+        providers.name AS provider_name
       FROM version_log
       JOIN quota ON version_log.quota_id = quota.id
       JOIN "users" ON version_log.user_id = "users".id


### PR DESCRIPTION
…fixed current day/month bug), updated Version Log page to match Hi-Fi

## Description
updated mavbar to match Hi-FI, updated calendar card to match Hi-FI and fixed current bug, updated version log page to high fi
## Screenshots/Media
<img width="1466" height="745" alt="image" src="https://github.com/user-attachments/assets/114c8f7b-3942-4daf-b6a7-197e2fda9c88" />

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the navbar, global header, and Audit Log to match Hi‑Fi designs. Fixes calendar sync and Audit Log provider data so dates and names show correctly. Aligns with the Audit Log and Navbar Hi‑Fi requirements in Linear 170.

- New Features
  - New top header with the CLCHC logo; navbar moved to the top-right with updated active styles; "Version Log" is now "Audit Log".
  - Audit Log UI: inline search and date picker with a 4‑column table (Editor, Action, Date & Time, Provider), alternating rows, and refined skeletons.
  - CalendarCard polish: Hi‑Fi button/spacing, Chevron trigger, "Today" label for the current date; app body background set to light gray.

- Bug Fixes
  - CalendarCard now syncs `tempDate` and `viewMonth` with the external `value` to prevent current day/month mismatches.
  - Audit Log uses `providers.name` and returns `providerName`, fixing provider search/display and date-time formatting in the table.

<sup>Written for commit 7fa62dd60d471214c7b0c7f54ce81fc0c9edd40a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

