### PR TITLE
192 fix delete user

### DIFF
--- a/client/src/components/user-directory/UserEditModal.jsx
+++ b/client/src/components/user-directory/UserEditModal.jsx
@@ -98,7 +98,7 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
     }
 
     try {
-      await deleteUser({ uid: currentFirebaseUid });
+      await deleteUser(currentFirebaseUid);
       if (onUpdated) await onUpdated();
       onClose();
     } catch (err) {
@@ -393,7 +393,7 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
                   py="10px"
                   h="41px"
                   onClick={async () => {
-                    onDelete();
+                    await onDelete();
                   }}
                   _hover={{ bg: "#A50F15" }}
                   isDisabled={deleteInput !== "Delete"}
@@ -416,7 +416,7 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
                   py="10px"
                   h="41px"
                   onClick={async () => {
-                    onApprove();
+                    await onApprove();
                   }}
                   _hover={{ bg: "#0C824D" }}
                 >


### PR DESCRIPTION
## Description
- fixed delete user in edit modal of user directory
- problem was that we initially passed in an object into the function instead of the actual uid string

## Screenshots/Media

## Issues
Closes #192

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the delete user flow in the User Directory edit modal by passing the `uid` string to `deleteUser` and awaiting async actions. Resolves failed deletes and UI race conditions per issue #192.

- **Bug Fixes**
  - Pass `currentFirebaseUid` directly to `deleteUser` (string, not object).
  - Await `onDelete()` and `onApprove()` in button handlers to finish actions before closing/updating.

<sup>Written for commit 1ee5a4650999c0550c882dea614a5c33512991c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

