### PR TITLE
190 calendar card hifi

### DIFF
--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -14,13 +14,10 @@ import {
   Text,
 } from "@chakra-ui/react";
 
-const DAYS_OF_WEEK = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+const DAYS_OF_WEEK = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
 const CalendarCard = ({ value, onChange }) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [tempDate, setTempDate] = useState(() => {
-    return value ? new Date(value + "T00:00:00") : new Date();
-  });
   const [viewMonth, setViewMonth] = useState(() => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
     return new Date(d.getFullYear(), d.getMonth(), 1);
@@ -28,25 +25,19 @@ const CalendarCard = ({ value, onChange }) => {
 
   useEffect(() => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
-    setTempDate(d);
     setViewMonth(new Date(d.getFullYear(), d.getMonth(), 1));
   }, [value]);
 
   const handleOpen = () => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
-    setTempDate(d);
     setViewMonth(new Date(d.getFullYear(), d.getMonth(), 1));
     setIsOpen(true);
   };
 
-  const handleCancel = () => {
-    setIsOpen(false);
-  };
-
-  const handleApply = () => {
-    const y = tempDate.getFullYear();
-    const m = String(tempDate.getMonth() + 1).padStart(2, "0");
-    const d = String(tempDate.getDate()).padStart(2, "0");
+  const handleDayClick = (day) => {
+    const y = viewMonth.getFullYear();
+    const m = String(viewMonth.getMonth() + 1).padStart(2, "0");
+    const d = String(day).padStart(2, "0");
     onChange(`${y}-${m}-${d}`);
     setIsOpen(false);
   };
@@ -122,28 +113,30 @@ const CalendarCard = ({ value, onChange }) => {
             align="center"
             mb={3}
           >
-            <IconButton
-              icon={<ChevronLeftIcon />}
-              size="sm"
-              variant="ghost"
-              onClick={prevMonth}
-              aria-label="Previous month"
-              borderRadius="md"
-            />
-            <Text
-              fontWeight="semibold"
-              fontSize="sm"
-            >
-              {monthLabel}
-            </Text>
-            <IconButton
-              icon={<ChevronRightIcon />}
-              size="sm"
-              variant="ghost"
-              onClick={nextMonth}
-              aria-label="Next month"
-              borderRadius="md"
-            />
+            <Flex align="center" gap={1}>
+              <Text fontWeight="semibold" fontSize="sm">
+                {monthLabel}
+              </Text>
+              <ChevronRightIcon color="gray.500" boxSize={3} />
+            </Flex>
+            <Flex gap={1}>
+              <IconButton
+                icon={<ChevronLeftIcon />}
+                size="sm"
+                variant="ghost"
+                onClick={prevMonth}
+                aria-label="Previous month"
+                borderRadius="md"
+              />
+              <IconButton
+                icon={<ChevronRightIcon />}
+                size="sm"
+                variant="ghost"
+                onClick={nextMonth}
+                aria-label="Next month"
+                borderRadius="md"
+              />
+            </Flex>
           </Flex>
 
           <Grid
@@ -171,10 +164,12 @@ const CalendarCard = ({ value, onChange }) => {
 
             {Array.from({ length: daysInMonth }).map((_, i) => {
               const day = i + 1;
+              const selectedDate = value ? new Date(value + "T00:00:00") : null;
               const isSelected =
-                tempDate.getFullYear() === year &&
-                tempDate.getMonth() === month &&
-                tempDate.getDate() === day;
+                selectedDate &&
+                selectedDate.getFullYear() === year &&
+                selectedDate.getMonth() === month &&
+                selectedDate.getDate() === day;
               const isToday =
                 today.getFullYear() === year &&
                 today.getMonth() === month &&
@@ -184,16 +179,19 @@ const CalendarCard = ({ value, onChange }) => {
                 <Button
                   key={day}
                   size="xs"
-                  variant={isSelected ? "solid" : "ghost"}
-                  colorScheme={isSelected ? "blue" : "gray"}
+                  variant="ghost"
                   borderRadius="full"
-                  onClick={() => setTempDate(new Date(year, month, day))}
-                  fontWeight={isToday && !isSelected ? "bold" : "normal"}
-                  color={isToday && !isSelected ? "blue.500" : undefined}
+                  onClick={() => handleDayClick(day)}
                   h="32px"
                   w="32px"
                   minW="32px"
                   p={0}
+                  bg={isSelected ? "pink.100" : undefined}
+                  color={isSelected ? "pink.600" : isToday ? "gray.800" : undefined}
+                  fontWeight={isToday || isSelected ? "bold" : "normal"}
+                  border={isToday && !isSelected ? "1.5px solid" : undefined}
+                  borderColor={isToday && !isSelected ? "gray.400" : undefined}
+                  _hover={{ bg: isSelected ? "pink.200" : "gray.100" }}
                 >
                   {day}
                 </Button>
@@ -201,26 +199,6 @@ const CalendarCard = ({ value, onChange }) => {
             })}
           </Grid>
 
-          <Flex
-            mt={4}
-            gap={2}
-            justify="flex-end"
-          >
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={handleCancel}
-            >
-              Cancel
-            </Button>
-            <Button
-              size="sm"
-              colorScheme="blue"
-              onClick={handleApply}
-            >
-              Apply
-            </Button>
-          </Flex>
         </PopoverBody>
       </PopoverContent>
     </Popover>

--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -16,7 +16,7 @@ import {
 
 const DAYS_OF_WEEK = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
-const CalendarCard = ({ value, onChange }) => {
+const CalendarCard = ({ value, onChange, fullWidth = false }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [viewMonth, setViewMonth] = useState(() => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
@@ -72,7 +72,7 @@ const CalendarCard = ({ value, onChange }) => {
     <Popover
       isOpen={isOpen}
       onClose={() => setIsOpen(false)}
-      placement="bottom-end"
+      placement={fullWidth ? "bottom-start" : "bottom-end"}
       closeOnBlur
     >
       <PopoverTrigger>
@@ -81,9 +81,9 @@ const CalendarCard = ({ value, onChange }) => {
           rightIcon={<ChevronDownIcon />}
           onClick={handleOpen}
           h="45px"
-          w="110px"
+          w={fullWidth ? "100%" : "110px"}
           px={3}
-          justifyContent="center"
+          justifyContent={fullWidth ? "space-between" : "center"}
           fontFamily="Lato"
           fontWeight="500"
           fontSize="14px"

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/DateInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/DateInput.jsx
@@ -2,11 +2,10 @@ import {
   Box,
   FormControl,
   FormLabel,
-  Input,
   InputGroup,
 } from "@chakra-ui/react";
 
-import { inputStyles } from "../tools/constants";
+import CalendarCard from "../../../common/CalendarCard";
 import { LockRightElement } from "../tools/shared";
 import { formatDateForDisplay } from "../tools/utils";
 
@@ -40,14 +39,10 @@ export const DateInput = ({ date, setDate, isLocked }) => {
           <LockRightElement />
         </InputGroup>
       ) : (
-        <Input
-          size="md"
-          type="date"
-          fontSize="14px"
-          {...inputStyles}
-          pr={isLocked ? "2.25rem" : undefined}
+        <CalendarCard
           value={date ?? ""}
-          onChange={(e) => setDate(e.target.value)}
+          onChange={setDate}
+          fullWidth
         />
       )}
     </FormControl>


### PR DESCRIPTION
## Description

Improved workflow of calendar card by making the date instantly apply when you click the date instead of having to click "apply" for confirmation. Also changed UI of the CalendarCard component.

Within date on the create quota button the calendar still used the generic calendar component, so applied CalendarCard component there for consistency.
## Screenshots/Media
Old calendar within create quota date: 

<img width="308" height="483" alt="image" src="https://github.com/user-attachments/assets/1db48fe3-14d8-48cc-9fcd-061d18b2358e" />

New calendar within both quota tracking date and create quota date:

<img width="296" height="335" alt="image" src="https://github.com/user-attachments/assets/f7dcaf06-c74b-429f-a268-d738d145191a" />


## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instant date selection in the calendar card with a refreshed UI, plus a consistent calendar experience in Create Quota. Implements the hi-fi CalendarCard from Linear 190.

- **New Features**
  - Clicking a day instantly sets the date; removed Apply/Cancel.
  - Polished UI: improved header, uppercase weekday labels, and clearer selected/today styles.
  - Added fullWidth support and adjusted popover placement.
  - Replaced the native date input with the calendar card in Create Quota; date format remains YYYY-MM-DD.

<sup>Written for commit ce8850903a7df60ea7c1e735c2918d116a4ccc4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

