### PR TITLE
Protect URLs

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -39,11 +39,21 @@ const App = () => {
                   <Route element={<Layout />}>
                     <Route
                       path="/user-directory"
-                      element={<UserDirectory />}
+                      element={
+                        <ProtectedRoute
+                          element={<UserDirectory />}
+                          allowedRoles={["ccm"]}
+                        />
+                      }
                     />
                     <Route
                       path="/pending-requests"
-                      element={<PendingRequestsPage />}
+                      element={
+                        <ProtectedRoute
+                          element={<PendingRequestsPage />}
+                          allowedRoles={["ccm"]}
+                        />
+                      }
                     />
 
                     <Route
@@ -51,6 +61,7 @@ const App = () => {
                       element={
                         <ProtectedRoute
                           element={<Settings />}
+                          allowedRoles={["viewer"]}
                         />
                       }
                     />
@@ -59,6 +70,7 @@ const App = () => {
                       element={
                         <ProtectedRoute
                           element={<QuotaTracking />}
+                          allowedRoles={["viewer"]}
                         />
                       }
                     />
@@ -67,6 +79,7 @@ const App = () => {
                       element={
                         <ProtectedRoute
                           element={<ProviderDirectoryPage />}
+                          allowedRoles={["viewer"]}
                         />
                       }
                     />
@@ -75,6 +88,7 @@ const App = () => {
                       element={
                         <ProtectedRoute
                           element={<VersionLogPage />}
+                          allowedRoles={["ccm"]}
                           />
                       }
                     />
@@ -85,31 +99,33 @@ const App = () => {
                   />
                   <Route
                     path="/pending-approval"
-                    element={<PendingApprovalPage />}
+                    element={
+                      <ProtectedRoute
+                        element={<PendingApprovalPage />}
+                        allowedRoles={["viewer"]}
+                      />
+                    }
                   />
-                  <Route
+                  {/* <Route
                     path="/signup"
                     element={<Signup />}
-                  />
-                  <Route
-                    path="/playground"
-                    element={<Playground />}
-                  />
-                  <Route
+                  /> */}
+                  {/* <Route
                     path="/dashboard"
                     element={<ProtectedRoute
                       element={<Dashboard />}
                     />}
-                  />
+                  /> */}
                   <Route
                     path="/version-log"
                     element={
                     <ProtectedRoute
                       element={<VersionLogPage />}
+                      allowedRoles={["ccm"]}
                       />
                     }
                   />
-                  <Route
+                  {/* <Route
                     path="/admin"
                     element={
                       <ProtectedRoute
@@ -117,7 +133,7 @@ const App = () => {
                         allowedRoles={"ccm"}
                       />
                     }
-                  />
+                  /> */}
                   <Route
                     path="/"
                     element={

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -56,15 +56,27 @@ const App = () => {
                     />
                     <Route
                       path="/quota-tracking/:date?"
-                      element={<QuotaTracking />}
+                      element={
+                        <ProtectedRoute
+                          element={<QuotaTracking />}
+                        />
+                      }
                     />
                     <Route
                       path="/provider-directory"
-                      element={<ProviderDirectoryPage />}
+                      element={
+                        <ProtectedRoute
+                          element={<ProviderDirectoryPage />}
+                        />
+                      }
                     />
                     <Route
                       path="/version-log/:date?"
-                      element={<VersionLogPage />}
+                      element={
+                        <ProtectedRoute
+                          element={<VersionLogPage />}
+                          />
+                      }
                     />
                   </Route>
                   <Route
@@ -85,11 +97,17 @@ const App = () => {
                   />
                   <Route
                     path="/dashboard"
-                    element={<ProtectedRoute element={<Dashboard />} />}
+                    element={<ProtectedRoute
+                      element={<Dashboard />}
+                    />}
                   />
                   <Route
                     path="/version-log"
-                    element={<VersionLogPage />}
+                    element={
+                    <ProtectedRoute
+                      element={<VersionLogPage />}
+                      />
+                    }
                   />
                   <Route
                     path="/admin"
@@ -103,10 +121,14 @@ const App = () => {
                   <Route
                     path="/"
                     element={
-                      <Navigate
-                        to="/login"
-                        replace
-                      />
+                    <ProtectedRoute
+                      element={
+                        <Navigate
+                          to="/login"
+                          replace
+                        />
+                      }
+                    />
                     }
                   />
                   <Route

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -121,14 +121,10 @@ const App = () => {
                   <Route
                     path="/"
                     element={
-                    <ProtectedRoute
-                      element={
-                        <Navigate
-                          to="/login"
-                          replace
-                        />
-                      }
-                    />
+                      <Navigate
+                        to="/login"
+                        replace
+                      />
                     }
                   />
                   <Route

--- a/client/src/components/ProtectedRoute.tsx
+++ b/client/src/components/ProtectedRoute.tsx
@@ -22,10 +22,12 @@ export const ProtectedRoute = ({
     ? allowedRoles
     : [allowedRoles];
   const isValidRole = getIsValidRole(roles, role ?? undefined);
+  const canAccessQuotaTracking = getIsValidRole(["viewer"], role ?? undefined);
+
   return currentUser && isValidRole ? (
     element
   ) : currentUser ? (
-    <Navigate to={"dashboard"} />
+    <Navigate to={canAccessQuotaTracking ? "/quota-tracking" : "/"} />
   ) : (
     <Navigate to={"/"} />
   );


### PR DESCRIPTION
## Description
Protect urls in App.tsx

## Screenshots/Media

## Issues
Closes #193 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects app routes with `ProtectedRoute` using role-based access, while keeping `/` public. Adds smarter redirects for logged-in users without permission. Closes #193.

- **New Features**
  - Role-protected routes: `viewer` — `/settings`, `/quota-tracking/:date?`, `/provider-directory`, `/pending-approval`; `ccm` — `/user-directory`, `/pending-requests`, `/version-log`, `/version-log/:date?`.
  - Redirects: unauthenticated users to `/`; logged-in users without permission to `/quota-tracking` if they have `viewer`, otherwise to `/`.

<sup>Written for commit 2e1948704b9bb57f14de932607bb4d8b58f1c0bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

