### PR TITLE
Ck animate progress bar 185

### DIFF
--- a/client/src/components/common/CustomCard.jsx
+++ b/client/src/components/common/CustomCard.jsx
@@ -37,7 +37,7 @@ export const CustomCard = ({ title, body, footer, footerUnderline, footerColor, 
         >
           {body}
         </Text>
-        {footer && (
+        {!!footer && (
           <Text
             fontSize="16px"
             fontFamily={"Lato"}

--- a/client/src/components/quota-tracking/AnimatedStatNumber.jsx
+++ b/client/src/components/quota-tracking/AnimatedStatNumber.jsx
@@ -1,17 +1,14 @@
 import { motion, useAnimation } from "framer-motion";
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 
-/**
- * Integer stat with count-up/down and a short nudge when the value rises or falls.
- */
 export function AnimatedStatNumber({ value, duration }) {
   const display = useAnimatedNumber(value, { duration });
   const controls = useAnimation();
   const prevRef = useRef(value);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prev = prevRef.current;
     if (prev === value) return;
     prevRef.current = value;
@@ -19,7 +16,11 @@ export function AnimatedStatNumber({ value, duration }) {
     const down = value < prev;
     controls.start({
       y: up ? [0, -3, 0] : down ? [0, 3, 0] : 0,
-      transition: { duration: 0.38, ease: [0.22, 1, 0.36, 1] },
+      transition: {
+        duration: 0.12,
+        delay: 0,
+        ease: up ? "easeOut" : [0.22, 1, 0.36, 1],
+      },
     });
   }, [value, controls]);
 

--- a/client/src/components/quota-tracking/AnimatedStatNumber.jsx
+++ b/client/src/components/quota-tracking/AnimatedStatNumber.jsx
@@ -1,0 +1,37 @@
+import { motion, useAnimation } from "framer-motion";
+import { useEffect, useRef } from "react";
+
+import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
+
+/**
+ * Integer stat with count-up/down and a short nudge when the value rises or falls.
+ */
+export function AnimatedStatNumber({ value, duration }) {
+  const display = useAnimatedNumber(value, { duration });
+  const controls = useAnimation();
+  const prevRef = useRef(value);
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    if (prev === value) return;
+    prevRef.current = value;
+    const up = value > prev;
+    const down = value < prev;
+    controls.start({
+      y: up ? [0, -3, 0] : down ? [0, 3, 0] : 0,
+      transition: { duration: 0.38, ease: [0.22, 1, 0.36, 1] },
+    });
+  }, [value, controls]);
+
+  return (
+    <motion.span
+      animate={controls}
+      style={{
+        display: "inline-block",
+        fontVariantNumeric: "tabular-nums",
+      }}
+    >
+      {display}
+    </motion.span>
+  );
+}

--- a/client/src/components/quota-tracking/AnimatedStatNumber.jsx
+++ b/client/src/components/quota-tracking/AnimatedStatNumber.jsx
@@ -1,5 +1,5 @@
 import { motion, useAnimation } from "framer-motion";
-import { useLayoutEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import { useAnimatedNumber } from "@/hooks/useAnimatedNumber";
 
@@ -8,7 +8,7 @@ export function AnimatedStatNumber({ value, duration }) {
   const controls = useAnimation();
   const prevRef = useRef(value);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const prev = prevRef.current;
     if (prev === value) return;
     prevRef.current = value;

--- a/client/src/components/quota-tracking/ProgressBar.jsx
+++ b/client/src/components/quota-tracking/ProgressBar.jsx
@@ -9,10 +9,12 @@ import { useCreateLog } from "@/contexts/hooks/data-fetching/useVersionLogs";
 import { useUserContext } from "@/contexts/hooks/useUserContext";
 import { MinusIcon, Plus} from "lucide-react";
 
-export default function ProgressBar({ quota }) {
+export default function ProgressBar({ quota, onDisplayedProgressChange }) {
   const quotaRef = useRef(null);
   const deltaQueueRef = useRef([]); // buffers +1 / -1 clicks
   const confirmedRef = useRef(null); // last server-confirmed value
+  const onProgressParentRef = useRef(onDisplayedProgressChange);
+  onProgressParentRef.current = onDisplayedProgressChange;
 
   const { mutateAsync: updateQuota } = useUpdateQuota();
   const { mutateAsync: createLog } = useCreateLog();
@@ -33,6 +35,11 @@ export default function ProgressBar({ quota }) {
       confirmedRef.current = quota.progress ?? 0;
     }
   }, [quota]);
+
+  useEffect(() => {
+    if (quota?.id == null) return;
+    onProgressParentRef.current?.(quota.id, currentProgress);
+  }, [quota?.id, currentProgress]);
 
   const clamp = (n) => Math.max(0, Math.min(n, maxProgress));
 

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -37,7 +37,13 @@ const SkeletonRows = () => {
   );
 };
 
-const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
+const QuotaTable = ({
+  rows,
+  loading,
+  onRowsUpdate,
+  onDisplayedProgressChange,
+  role,
+}) => {
   const isViewer = role === "viewer";
   const [editingQuotaId, setEditingQuotaId] = useState(null);
   const [selectedRowId, setSelectedRowId] = useState(null);
@@ -196,7 +202,10 @@ const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
                 {/* Progress */}
                 <Td {...tdProps} padding="16px 24px">
                   <Box onClick={(e) => e.stopPropagation()}>
-                    <ProgressBar quota={row} />
+                    <ProgressBar
+                      quota={row}
+                      onDisplayedProgressChange={onDisplayedProgressChange}
+                    />
                   </Box>
                 </Td>
 

--- a/client/src/components/quota-tracking/QuotaTrackingPage.jsx
+++ b/client/src/components/quota-tracking/QuotaTrackingPage.jsx
@@ -25,6 +25,7 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { useNavigate, useParams } from "react-router-dom";
 
 import CalendarCard from "../common/CalendarCard";
+import { AnimatedStatNumber } from "./AnimatedStatNumber";
 import QuotaTable from "./QuotaTable";
 
 const SkeletonCard = () => {
@@ -205,27 +206,43 @@ export const QuotaTracking = () => {
             <>
               <CustomCard
                 title="Total Progress"
-                body={`${stats.totalProgress}/${stats.totalQuota}`}
+                body={
+                  <>
+                    <AnimatedStatNumber value={stats.totalProgress} />
+                    {" / "}
+                    <AnimatedStatNumber value={stats.totalQuota} />
+                  </>
+                }
                 height="172.826px"
                 flex={1}
               />
               <CustomCard
                 title="Completion Rate"
-                body={`${stats.rate}%`}
+                body={
+                  <>
+                    <AnimatedStatNumber value={stats.rate} />
+                    {"%"}
+                  </>
+                }
                 footer="Overall progress"
                 height="172.826px"
                 flex={1}
               />
               <CustomCard
                 title="Active Providers"
-                body={stats.activeProviders.toString()}
-                footer={`${stats.differentLocations} locations`}
+                body={<AnimatedStatNumber value={stats.activeProviders} />}
+                footer={
+                  <>
+                    <AnimatedStatNumber value={stats.differentLocations} />
+                    {" locations"}
+                  </>
+                }
                 height="172.826px"
                 flex={1}
               />
               <CustomCard
                 title="Needs Attention"
-                body={stats.needsAttention.toString()}
+                body={<AnimatedStatNumber value={stats.needsAttention} />}
                 footer=""
                 height="172.826px"
                 flex={1}

--- a/client/src/components/quota-tracking/QuotaTrackingPage.jsx
+++ b/client/src/components/quota-tracking/QuotaTrackingPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { AddIcon, SearchIcon } from "@chakra-ui/icons";
 import {
@@ -97,9 +97,42 @@ export const QuotaTracking = () => {
     provider: providerQuery,
   });
 
+  /** Live progress from each ProgressBar (optimistic UI) merged into list totals / stats */
+  const [displayedProgressById, setDisplayedProgressById] = useState({});
+
+  const handleDisplayedProgressChange = useCallback((quotaId, progress) => {
+    const key = String(quotaId);
+    setDisplayedProgressById((prev) => {
+      if (prev[key] === progress) return prev;
+      return { ...prev, [key]: progress };
+    });
+  }, []);
+
+  useEffect(() => {
+    const valid = new Set(quotas.map((q) => String(q.id)));
+    setDisplayedProgressById((prev) => {
+      let next = prev;
+      for (const k of Object.keys(prev)) {
+        if (!valid.has(k)) {
+          if (next === prev) next = { ...prev };
+          delete next[k];
+        }
+      }
+      return next;
+    });
+  }, [quotas]);
+
+  const mergedQuotas = useMemo(() => {
+    return quotas.map((q) => {
+      const live = displayedProgressById[String(q.id)];
+      if (live === undefined) return q;
+      return { ...q, progress: live };
+    });
+  }, [quotas, displayedProgressById]);
+
   const stats = useMemo(() => {
     // undefined quotas
-    if (!quotas || quotas.length === 0) {
+    if (!mergedQuotas || mergedQuotas.length === 0) {
       return {
         totalProgress: 0,
         totalQuota: 0,
@@ -115,7 +148,7 @@ export const QuotaTracking = () => {
     const distinctProviders = new Set();
     const distinctLocations = new Set();
 
-    quotas.forEach((q) => {
+    mergedQuotas.forEach((q) => {
       // totals
       const p = Number(q.progress) || 0;
       const t = Number(q.quota) || 0;
@@ -139,7 +172,7 @@ export const QuotaTracking = () => {
       differentLocations: distinctLocations.size,
       needsAttention: needsAttentionCount,
     };
-  }, [quotas]);
+  }, [mergedQuotas]);
 
   const {
     isOpen: isCreateDrawerOpen,
@@ -264,9 +297,10 @@ export const QuotaTracking = () => {
       </InputGroup>
 
       <QuotaTable
-        rows={quotas}
+        rows={mergedQuotas}
         loading={isLoading}
         role={role}
+        onDisplayedProgressChange={handleDisplayedProgressChange}
       />
 
       <QuotaDrawer

--- a/client/src/hooks/useAnimatedNumber.js
+++ b/client/src/hooks/useAnimatedNumber.js
@@ -1,14 +1,24 @@
 import { animate } from "framer-motion";
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
+function displayInteger(current, target) {
+
+  if (Math.abs(current - target) < 1e-4) {
+    return Math.round(target);
+  }
+  if (target > current) {
+    return Math.min(target, Math.ceil(current - 1e-9));
+  }
+  return Math.max(target, Math.floor(current + 1e-9));
+}
 
 export function useAnimatedNumber(target, options = {}) {
-  const { duration = 0.45 } = options;
+  const { duration = 0.12 } = options;
   const [current, setCurrent] = useState(() => target);
   const lastRef = useRef(target);
   const didMount = useRef(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!didMount.current) {
       didMount.current = true;
       lastRef.current = target;
@@ -17,19 +27,26 @@ export function useAnimatedNumber(target, options = {}) {
     }
 
     const from = lastRef.current;
+    if (from === target) {
+      setCurrent(target);
+      return;
+    }
+
+    const goingUp = target > from;
     const controls = animate(from, target, {
       duration,
-      ease: [0.22, 1, 0.36, 1],
+      ease: goingUp ? "easeOut" : [0.22, 1, 0.36, 1],
       onUpdate: (v) => {
         lastRef.current = v;
         setCurrent(v);
       },
       onComplete: () => {
         lastRef.current = target;
+        setCurrent(target);
       },
     });
     return () => controls.stop();
   }, [target, duration]);
 
-  return Math.round(current);
+  return displayInteger(current, target);
 }

--- a/client/src/hooks/useAnimatedNumber.js
+++ b/client/src/hooks/useAnimatedNumber.js
@@ -1,0 +1,35 @@
+import { animate } from "framer-motion";
+import { useEffect, useRef, useState } from "react";
+
+
+export function useAnimatedNumber(target, options = {}) {
+  const { duration = 0.45 } = options;
+  const [current, setCurrent] = useState(() => target);
+  const lastRef = useRef(target);
+  const didMount = useRef(false);
+
+  useEffect(() => {
+    if (!didMount.current) {
+      didMount.current = true;
+      lastRef.current = target;
+      setCurrent(target);
+      return;
+    }
+
+    const from = lastRef.current;
+    const controls = animate(from, target, {
+      duration,
+      ease: [0.22, 1, 0.36, 1],
+      onUpdate: (v) => {
+        lastRef.current = v;
+        setCurrent(v);
+      },
+      onComplete: () => {
+        lastRef.current = target;
+      },
+    });
+    return () => controls.stop();
+  }, [target, duration]);
+
+  return Math.round(current);
+}

--- a/client/src/hooks/useAnimatedNumber.js
+++ b/client/src/hooks/useAnimatedNumber.js
@@ -1,5 +1,5 @@
 import { animate } from "framer-motion";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function displayInteger(current, target) {
 
@@ -18,7 +18,7 @@ export function useAnimatedNumber(target, options = {}) {
   const lastRef = useRef(target);
   const didMount = useRef(false);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     if (!didMount.current) {
       didMount.current = true;
       lastRef.current = target;


### PR DESCRIPTION
## Description
Implemented animations for the Quota Tracking page with the addition of two files: useAnimatedNumber.js and AnimatedStatNumber.jsx.

## Screenshots/Media
Can't really upload, but you can check it out.

## Issues
Closes #185 

<!-- [Optional]
## Additional Notes
I used the implemented optimistic to get around the delay, but I am not 100% sure if it fixes it.
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds animated progress and stat numbers to the Quota Tracking page with optimistic updates, so totals reflect live changes without lag (closes #185). Also fixes a footer render edge case in `CustomCard`.

- **New Features**
  - Introduced `useAnimatedNumber` and `AnimatedStatNumber` powered by `framer-motion` with smooth transitions and a subtle bump on change.
  - `ProgressBar` now emits `onDisplayedProgressChange`; `QuotaTrackingPage` merges live progress into totals, and cards animate values (Total Progress, Completion Rate, Active Providers, Needs Attention).

- **Bug Fixes**
  - Prevented stray "0" footers in `CustomCard` by using `!!footer`.
  - Clean up stale progress entries when quotas change to keep stats accurate.

<sup>Written for commit d5182aa44930dbd2afa2af91a2613e8f58fe1510. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

