### PR TITLE
191 empty table states

### DIFF
--- a/client/src/components/provider-directory/CategoryDrawer.jsx
+++ b/client/src/components/provider-directory/CategoryDrawer.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from "react";
 
-import { DeleteIcon, HamburgerIcon } from "@chakra-ui/icons";
+import { AddIcon, DeleteIcon, HamburgerIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -20,6 +20,7 @@ import {
   RadioGroup,
   Skeleton,
   Stack,
+  Text,
   useToast,
 } from "@chakra-ui/react";
 
@@ -320,7 +321,35 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
                     items={categories.map((cat) => cat.id)}
                     strategy={verticalListSortingStrategy}
                   >
-                    {categories.map((cat) => (
+                    {categories.length === 0 ? (
+                      <Box display="flex" flexDirection="column" alignItems="center" pb="16px" borderRadius="4px" border="1px solid" borderColor="gray.200">
+                        <Box display="flex" alignItems="center" justifyContent="center" w={"80%"} px={"10.5px"} pt={"88px"}>
+                          <Text fontFamily="Inter" fontSize="14px" color="rgba(88, 103, 113, 0.73)" fontWeight={"normal"} textAlign="center" mb={"88px"}>
+                            No categories added yet. Add a new category now.
+                          </Text>
+                        </Box>
+                        <Button
+                          onClick={() => setShowForm(!showForm)}
+                          display="flex"
+                          w="90%"
+                          h="40px"
+                          px="16px"
+                          justifyContent="center"
+                          alignItems="center"
+                          iconSpacing="8px"
+                          borderRadius="10px"
+                          bg="#EDF2F7"
+                          color="gray.600"
+                          fontFamily="Lato"
+                          fontSize="14px"
+                          fontWeight="normal"
+                          leftIcon={<AddIcon boxSize="10px" />}
+                          _hover={{ bg: "gray.200" }}
+                        >
+                          Add New Category
+                        </Button>
+                      </Box>
+                    ) : categories.map((cat) => (
                       <SortableCategory
                         key={cat.id}
                         category={cat}
@@ -330,9 +359,11 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
                   </SortableContext>
                 </DndContext>
 
-                <Button onClick={() => setShowForm(!showForm)}>
-                  Add Category
-                </Button>
+                {categories.length > 0 && (
+                  <Button onClick={() => setShowForm(!showForm)}>
+                    Add Category
+                  </Button>
+                )}
 
                 {showForm && (
                   <Stack

--- a/client/src/components/provider-directory/ProviderDirectoryPage.jsx
+++ b/client/src/components/provider-directory/ProviderDirectoryPage.jsx
@@ -214,6 +214,11 @@ export const ProviderDirectoryPage = () => {
                 : undefined
             }
             loading={isLoading || loadingCategories}
+            onCreateProvider={
+              role === "ccm" || role === "master"
+                ? openCreateProviderDrawer
+                : undefined
+            }
           />
         </Box>
       ) : (

--- a/client/src/components/provider-directory/ProviderTable.jsx
+++ b/client/src/components/provider-directory/ProviderTable.jsx
@@ -1,4 +1,6 @@
 import {
+  Box,
+  Button,
   Skeleton,
   Table,
   TableContainer,
@@ -12,9 +14,12 @@ import {
   Wrap,
   WrapItem,
 } from "@chakra-ui/react";
+import { AddIcon } from "@chakra-ui/icons";
+import { MdPersonAdd } from "react-icons/md";
 
 import TextPopup from "@/components/common/TextPopup";
 import { useTags } from "@/contexts/hooks/data-fetching/useTags";
+import { color } from "framer-motion";
 
 const SkeletonHeader = () => {
   return (
@@ -67,6 +72,7 @@ export default function ProviderTable({
   onProviderSelect,
   onProviderDoubleClick,
   loading,
+  onCreateProvider,
 }) {
   const { data: tagsData } = useTags();
   const tagsMap = tagsData?.tagsMap ?? {};
@@ -93,6 +99,13 @@ export default function ProviderTable({
     borderColor: "gray.200",
   };
 
+  const defaultHeaderCells = (
+    <>
+      <Th {...fixedThProps}>Provider</Th>
+      <Th {...fixedThProps}>NPI/License</Th>
+    </>
+  );
+
   const Header = () => {
     const dynamicColumns = sortedCategories.map((cat) => (
       <Th
@@ -112,8 +125,7 @@ export default function ProviderTable({
         zIndex={1}
       >
         <Tr>
-          <Th {...fixedThProps}>Provider</Th>
-          <Th {...fixedThProps}>NPI/License</Th>
+          {defaultHeaderCells}
           {dynamicColumns}
           <Th {...fixedThProps} borderRight="none">Long Term Notes</Th>
         </Tr>
@@ -357,6 +369,51 @@ export default function ProviderTable({
           <>
             <SkeletonHeader />
             <SkeletonBody />
+          </>
+  
+        ) : providers.length === 0 ? (
+          <>
+            <Thead bg="#EBEBEB" h="40px" position="sticky" top={0} zIndex={1}>
+              <Tr>
+                {defaultHeaderCells}
+                <Th {...fixedThProps} borderRight="none">Long Term Notes</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              <Tr>
+                <Td colSpan={1000} height={"424px"} textAlign="center" py={10}>
+                  <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
+                    <MdPersonAdd size={69} color="#586771" />
+                    <Text fontFamily="Lato" fontSize="22px" color="rgba(88, 103, 113, 0.73)">
+                      No providers added yet.
+                    </Text>
+                    <Text fontFamily="Lato" fontSize="16px" color="rgba(88, 103, 113, 0.73)">
+                      Add a provider to view and manage their information.
+                    </Text>
+                    <Button
+                      marginTop={"29px"}
+                      bg="#35639D"
+                      color="white"
+                      h={"40px"}
+                      w={"211px"}
+                      padding={"0 16px"}
+                      iconSpacing={"8px"}
+                      fontFamily={"Inter"}
+                      fontSize={"16px"}
+                      fontStyle={"normal"}
+                      fontWeight={"light"}
+                      lineHeight={"28px"}
+                      _hover={{ bg: "#35639D" }}
+                      leftIcon={<AddIcon boxSize={"12px"}/>}
+                      borderRadius={"6px"}
+                      onClick={onCreateProvider}
+                    >
+                      Create Provider
+                    </Button>
+                  </Box>
+                </Td>
+              </Tr>
+            </Tbody>
           </>
         ) : (
           <>

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -15,6 +15,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 
+import { MdSentimentDissatisfied } from "react-icons/md";
+
 import TextPopup from "@/components/common/TextPopup";
 import ProgressBar from "@/components/quota-tracking/ProgressBar";
 import QuotaDrawer from "@/components/quota-tracking/QuotaDrawer";
@@ -137,6 +139,17 @@ const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
         <Tbody>
           {loading ? (
             <SkeletonRows />
+          ) : rows.length === 0 ? (
+            <Tr>
+              <Td colSpan={5} height={"240px"} textAlign="center" py={10}>
+                <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
+                  <MdSentimentDissatisfied size={69} color="#586771" />
+                  <Text fontFamily="Lato" fontSize="18px" color="gray.500">
+                    No quotas found.
+                  </Text>
+                </Box>
+              </Td>
+            </Tr>
           ) : (
             rows.map((row) => (
               <Tr

--- a/client/src/components/user-directory/UserTable.jsx
+++ b/client/src/components/user-directory/UserTable.jsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 // import { Icon } from "@chakra-ui/icons";
 import {
   Badge,
+  Box,
   HStack,
   IconButton,
   Skeleton,
@@ -18,7 +19,7 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 
-import { MdCreate } from "react-icons/md";
+import { MdCreate, MdSentimentDissatisfied } from "react-icons/md";
 
 import UserEditModal from "./UserEditModal";
 
@@ -148,6 +149,17 @@ export default function UserTable({
           <Tbody>
             {loading ? (
               <SkeletonRows />
+            ) : users.length === 0 ? (
+              <Tr>
+                <Td colSpan={5} height={"360px"} textAlign="center" py={10}>
+                  <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
+                    <MdSentimentDissatisfied size={69} color="#586771" />
+                    <Text fontFamily="Lato" fontSize="18px" color="gray.500">
+                      No users found.
+                    </Text>
+                  </Box>
+                </Td>
+              </Tr>
             ) : (
               users.map((user) => (
                 <Tr key={user.id} borderBottom="1px solid" borderColor="gray.200">

--- a/client/src/components/user-directory/UserTable.jsx
+++ b/client/src/components/user-directory/UserTable.jsx
@@ -151,7 +151,7 @@ export default function UserTable({
               <SkeletonRows />
             ) : users.length === 0 ? (
               <Tr>
-                <Td colSpan={5} height={"360px"} textAlign="center" py={10}>
+                <Td colSpan={4} height={"360px"} textAlign="center" py={10}>
                   <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
                     <MdSentimentDissatisfied size={69} color="#586771" />
                     <Text fontFamily="Lato" fontSize="18px" color="gray.500">

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -106,7 +106,7 @@ const VersionLogTable = ({ loading, logs }) => {
           <Tbody>
             {!loading && logs.length === 0 && (
               <Tr>
-                <Td colSpan={5} height={"424px"} textAlign="center" py={10}>
+                <Td colSpan={4} height={"424px"} textAlign="center" py={10}>
                   <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
                     <MdSentimentDissatisfied size={69} color="#586771" />
                     <Text fontFamily="Lato" fontSize="18px" color="gray.500">

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import {
+  Box,
   Skeleton,
   Table,
   TableContainer,
@@ -12,6 +13,8 @@ import {
   Tr,
   VStack,
 } from "@chakra-ui/react";
+
+import { MdSentimentDissatisfied } from "react-icons/md";
 
 const SkeletonRows = () => {
   return (
@@ -103,15 +106,13 @@ const VersionLogTable = ({ loading, logs }) => {
           <Tbody>
             {!loading && logs.length === 0 && (
               <Tr>
-                <Td
-                  colSpan={4}
-                  py="40px"
-                  textAlign="center"
-                  color="gray.400"
-                  fontFamily="Inter"
-                  fontSize="14px"
-                >
-                  No version history available
+                <Td colSpan={5} height={"424px"} textAlign="center" py={10}>
+                  <Box display="flex" flexDirection="column" alignItems="center" gap={2}>
+                    <MdSentimentDissatisfied size={69} color="#586771" />
+                    <Text fontFamily="Lato" fontSize="18px" color="gray.500">
+                      No audit logs found.
+                    </Text>
+                  </Box>
                 </Td>
               </Tr>
             )}


### PR DESCRIPTION
## Description
implemented empty table states for quota, provider, user, audit pages and category drawer

## Screenshots/Media
<img width="1918" height="977" alt="image" src="https://github.com/user-attachments/assets/262b3b91-fa9d-4037-ab2c-d73b8ae13a21" />
<img width="1918" height="990" alt="image" src="https://github.com/user-attachments/assets/f7e5dd52-a702-45f0-820f-6eddf1533b8e" />
<img width="1917" height="978" alt="image" src="https://github.com/user-attachments/assets/f1331040-41c8-4fdc-a6fd-a6c5f37781c4" />
<img width="1918" height="968" alt="image" src="https://github.com/user-attachments/assets/b38dee4b-15a7-4d19-ab42-8918caf9c60d" />
<img width="1917" height="973" alt="image" src="https://github.com/user-attachments/assets/272c02d1-ca44-437a-a4eb-41c490f97230" />


## Issues
Closes #191 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds consistent empty states for provider, quota, user, and audit tables, plus the category drawer, with clear messaging and quick actions where relevant. Completes #191.

- **New Features**
  - Provider table: empty state with icon, copy, and a “Create Provider” button when `onCreateProvider` is provided; header stays visible. `ProviderDirectoryPage` now passes `onCreateProvider` for `ccm`/`master` roles.
  - Quota table: empty state with icon and “No quotas found.”
  - User table: empty state with icon and “No users found.”
  - Audit (version log) table: empty state with icon and “No audit logs found.”
  - Category drawer: empty state with guidance and “Add New Category” button; shows the add button when categories exist.

- **Bug Fixes**
  - Version log empty state `colSpan` set to 4 to match headers and prevent layout issues.

<sup>Written for commit 3cbba5e59b3231caa4d0890748736b732aff5027. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

