### PR TITLE
Animation for progress bar

### DIFF
--- a/client/src/components/quota-tracking/ProgressBar.jsx
+++ b/client/src/components/quota-tracking/ProgressBar.jsx
@@ -148,7 +148,16 @@ export default function ProgressBar({ quota }) {
           borderRadius="4px"
           background="rgba(0,0,0,0.06)"
           marginx="6px"
-          sx={{ "& > div": { backgroundColor: "#38A169" } }}
+          sx={{
+            "& > div": {
+              backgroundColor: "#38A169",
+              transition:
+                "width 0.4s cubic-bezier(0.33, 1, 0.68, 1), background-color 0.2s ease",
+            },
+            "@media (prefers-reduced-motion: reduce)": {
+              "& > div": { transition: "none" },
+            },
+          }}
         />
 
         <Button

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/QuotaProgress.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/QuotaProgress.jsx
@@ -52,6 +52,15 @@ export function QuotaProgress({
           bg="gray.200"
           my={2}
           colorScheme="green"
+          sx={{
+            "& > div": {
+              transition:
+                "width 0.4s cubic-bezier(0.33, 1, 0.68, 1), background-color 0.2s ease",
+            },
+            "@media (prefers-reduced-motion: reduce)": {
+              "& > div": { transition: "none" },
+            },
+          }}
         />
         <Box
           px={4}


### PR DESCRIPTION
## Description
Implemented animation for progress bar rather than the cards. You can disregard my old pr as it does not comply with the assigned issue. 

## Screenshots/Media
No images possible.

## Issues
Closes # 185

<!-- [Optional]
## Additional Notes
This should be the animation on the hi-fi. Sorry that I misunderstood the issue. Let me know if there are any adjustments with the speed of the animation.
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds smooth width and color transitions to the quota progress bar to match the hi‑fi spec, moving animation from cards to the bar. Applies the same behavior in `ProgressBar` and `QuotaProgress`, and disables animations when `prefers-reduced-motion` is set (closes #185).

<sup>Written for commit 3b483e6ca0b115ba3233e2488ed6b0e5da70a224. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

