### PR TITLE
feat: custom select for quota drawer

### DIFF
--- a/client/src/components/common/CustomSelect.jsx
+++ b/client/src/components/common/CustomSelect.jsx
@@ -1,0 +1,72 @@
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuItemOption,
+  MenuList,
+  MenuOptionGroup,
+} from "@chakra-ui/react";
+
+export default function CustomSelect({
+  options,
+  value,
+  setValue,
+  styleProps = {},
+}) {
+  const selectedLabel = options.find((opt) => opt.value === value)?.label;
+
+  return (
+    <Menu
+      matchWidth
+      strategy="fixed"
+    >
+      <MenuButton
+        as={Button}
+        w="100%"
+        rightIcon={<ChevronDownIcon />}
+        bg="white"
+        borderWidth="1px"
+        borderColor="gray.300"
+        borderRadius="6px"
+        fontWeight="normal"
+        fontSize="14px"
+        textAlign="left"
+        color={selectedLabel ? "inherit" : "gray.400"}
+        _hover={{ bg: "white", borderColor: "gray.400" }}
+        _active={{ bg: "white" }}
+        _expanded={{ borderColor: "blue.500", boxShadow: "0 0 0 1px #3182ce" }}
+        _disabled={{
+          bg: "gray.50",
+          color: "gray.500",
+          opacity: 1,
+          cursor: "not-allowed",
+        }}
+        {...styleProps} // In case we use this somewhere else
+      >
+        {selectedLabel || "Select option"}
+      </MenuButton>
+
+      <MenuList
+        zIndex="popover"
+        maxH="200px" // To prevent overflow, but scrolling might not be obvious -@grace
+        overflowY="auto"
+      >
+        <MenuOptionGroup
+          type="radio"
+          value={value}
+          onChange={(newVal) => setValue(newVal)}
+        >
+          {options.map((opt) => (
+            <MenuItemOption
+              key={opt.value}
+              value={opt.value}
+            >
+              {opt.label}
+            </MenuItemOption>
+          ))}
+        </MenuOptionGroup>
+      </MenuList>
+    </Menu>
+  );
+}

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -3,13 +3,12 @@ import {
   FormControl,
   FormLabel,
   InputGroup,
-  Select,
   Skeleton,
 } from "@chakra-ui/react";
 
+import CustomSelect from "@/components/common/CustomSelect";
 import { useLocations } from "@/contexts/hooks/data-fetching/useLocations";
 
-import { selectStyles } from "../tools/constants";
 import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locationId, setLocationId, isLocked }) {
@@ -30,6 +29,10 @@ export function LocationDropdown({ locationId, setLocationId, isLocked }) {
     );
   }
 
+  const options = locations.map((l) => ({
+    value: String(l.id),
+    label: l.tagValue,
+  }));
   const selectedLocation = locations.find(
     (location) => String(location.id) === String(locationId)
   );
@@ -43,7 +46,9 @@ export function LocationDropdown({ locationId, setLocationId, isLocked }) {
       <FormLabel
         fontSize="14px"
         color="#113D64"
-      >Location</FormLabel>
+      >
+        Location
+      </FormLabel>
       {isLocked ? (
         <InputGroup>
           <Box
@@ -63,25 +68,11 @@ export function LocationDropdown({ locationId, setLocationId, isLocked }) {
           <LockRightElement />
         </InputGroup>
       ) : (
-        <InputGroup>
-          <Select
-            {...selectStyles}
-            placeholder=" "
-            pr={isLocked ? "2.25rem" : undefined}
-            value={locationId === "" ? "" : String(locationId)}
-            onChange={(e) => setLocationId(Number(e.target.value))}
-          >
-            {locations &&
-              locations.map((location) => (
-                <option
-                  key={location.id}
-                  value={location.id}
-                >
-                  {location.tagValue}
-                </option>
-              ))}
-          </Select>
-        </InputGroup>
+        <CustomSelect
+          options={options}
+          value={locationId === "" ? "" : String(locationId)}
+          setValue={(val) => setLocationId(Number(val))}
+        />
       )}
     </FormControl>
   );

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -3,13 +3,12 @@ import {
   FormControl,
   FormLabel,
   InputGroup,
-  Select,
   Skeleton,
 } from "@chakra-ui/react";
 
+import CustomSelect from "@/components/common/CustomSelect";
 import { useProvidersSummary } from "@/contexts/hooks/data-fetching/useProviders";
 
-import { selectStyles } from "../tools//constants";
 import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providerId, setProviderId, isLocked }) {
@@ -28,6 +27,10 @@ export function ProviderDropdown({ providerId, setProviderId, isLocked }) {
     );
   }
 
+  const options = providers.map((p) => ({
+    value: String(p.id),
+    label: p.name,
+  }));
   const selectedProvider = providers.find(
     (provider) => String(provider.id) === String(providerId)
   );
@@ -40,7 +43,9 @@ export function ProviderDropdown({ providerId, setProviderId, isLocked }) {
       <FormLabel
         fontSize="14px"
         color="#113D64"
-      >Provider</FormLabel>
+      >
+        Provider
+      </FormLabel>
       {isLocked ? (
         <InputGroup>
           <Box
@@ -59,28 +64,11 @@ export function ProviderDropdown({ providerId, setProviderId, isLocked }) {
           <LockRightElement />
         </InputGroup>
       ) : (
-        <InputGroup>
-          <Select
-            {...selectStyles}
-            fontSize="14px"
-            placeholder=" "
-            pr={isLocked ? "2.25rem" : undefined}
-            value={providerId === "" ? "" : String(providerId)}
-            onChange={(e) => {
-              setProviderId(Number(e.target.value));
-            }}
-          >
-            {providers &&
-              providers.map((provider) => (
-                <option
-                  key={provider.id}
-                  value={provider.id}
-                >
-                  {provider.name}
-                </option>
-              ))}
-          </Select>
-        </InputGroup>
+        <CustomSelect
+          options={options}
+          value={providerId === "" ? "" : String(providerId)}
+          setValue={(val) => setProviderId(Number(val))}
+        />
       )}
     </FormControl>
   );

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
@@ -1,12 +1,8 @@
-import {
-  Box,
-  FormControl,
-  FormLabel,
-  InputGroup,
-  Select,
-} from "@chakra-ui/react";
+import { Box, FormControl, FormLabel, InputGroup } from "@chakra-ui/react";
 
-import { selectStyles, TYPE_OPTIONS } from "../tools/constants";
+import CustomSelect from "@/components/common/CustomSelect";
+
+import { TYPE_OPTIONS } from "../tools/constants";
 import { LockRightElement } from "../tools/shared";
 
 export const TypeInput = ({ type, setType, isLocked }) => {
@@ -18,7 +14,9 @@ export const TypeInput = ({ type, setType, isLocked }) => {
       <FormLabel
         fontSize="14px"
         color="#113D64"
-      >Type</FormLabel>
+      >
+        Type
+      </FormLabel>
       {isLocked ? (
         <InputGroup>
           <Box
@@ -37,26 +35,11 @@ export const TypeInput = ({ type, setType, isLocked }) => {
           <LockRightElement />
         </InputGroup>
       ) : (
-        <InputGroup>
-          <Select
-            {...selectStyles}
-            fontSize="14px"
-            placeholder=" "
-            pr={isLocked ? "2.25rem" : undefined}
-            value={type ?? ""}
-            onChange={(e) => setType(e.target.value)}
-          >
-            {TYPE_OPTIONS.map(({ value, label }) => (
-              <option
-                key={value}
-                value={value}
-              >
-                {label}
-              </option>
-            ))}
-          </Select>
-          {isLocked && <LockRightElement />}
-        </InputGroup>
+        <CustomSelect
+          options={TYPE_OPTIONS}
+          value={type ?? ""}
+          setValue={setType}
+        />
       )}
     </FormControl>
   );


### PR DESCRIPTION
## Description
Added custom select component. Currently created to support quota drawer rn since that's the only place I saw we could use them in, but we can just change the props a lil bit if its needed somewhere else with a diff style

## Screenshots/Media

<img width="559" height="772" alt="image" src="https://github.com/user-attachments/assets/68ade50b-a95f-42f5-9570-7c41e0b78b6d" />


## Issues
Closes #187 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `CustomSelect` and replaces native selects in the quota drawer (Location, Provider, Type) to standardize dropdown styling and behavior. Implements the dropdown requirement in #187.

- **New Features**
  - `CustomSelect` built on `@chakra-ui/react` `Menu` for full-width, focusable dropdowns with a chevron.
  - Props: `options` [{ value, label }], `value`, `setValue`, optional `styleProps`; shows “Select option” when empty and supports scroll for long lists.

- **Refactors**
  - `LocationDropdown`, `ProviderDropdown`, and `TypeInput` now use `CustomSelect` with simple string/number mapping.
  - Locked state UI unchanged with `LockRightElement`.
  - Removed local `Select` styles and options mapping duplication.

<sup>Written for commit d418b29ec041ec7f588ca109f8b923e376edb6ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

