### PR TITLE
213 loading skeletons in quota tracking sidebar

### DIFF
--- a/client/src/components/quota-tracking/QuotaDrawer.jsx
+++ b/client/src/components/quota-tracking/QuotaDrawer.jsx
@@ -11,6 +11,7 @@ import {
   Stack,
   Text,
   useDisclosure,
+  Skeleton
 } from "@chakra-ui/react";
 
 import {
@@ -35,7 +36,6 @@ import { TypeInput } from "./quota-drawer/form-fields/TypeInput";
 import { NotificationBanner } from "./quota-drawer/NotificationBanner";
 import { QuotaDrawerFooter } from "./quota-drawer/QuotaDrawerFooter";
 import { drawerTitle } from "./quota-drawer/tools/constants";
-import { SkeletonBody } from "./quota-drawer/tools/shared";
 import {
   formatDateForInput,
   formatTimeForInput,
@@ -311,7 +311,48 @@ export default function QuotaDrawer({
         </DrawerHeader>
 
         {isDrawerLoading ? (
-          <SkeletonBody />
+          <DrawerBody padding="30px 24px 30px 24px">
+          <Stack gap={4}>
+
+            <Stack gap={2}>
+              <Skeleton height="14px" width="70px" />
+              <Skeleton height="40px" borderRadius="6px" />
+            </Stack>
+
+            <Flex justify="space-between" gap={4}>
+              <Stack flex={1} gap={2}>
+                <Skeleton height="14px" width="40px" />
+                <Skeleton height="40px" borderRadius="6px" />
+              </Stack>
+              <Stack flex={1} gap={2}>
+                <Skeleton height="14px" width="55px" />
+                <Skeleton height="40px" borderRadius="6px" />
+              </Stack>
+            </Flex>
+
+            <Flex justify="space-between" gap={4}>
+              <Stack flex={1} gap={2}>
+                <Skeleton height="14px" width="65px" />
+                <Skeleton height="40px" borderRadius="6px" />
+              </Stack>
+              <Stack flex={1} gap={2}>
+                <Skeleton height="14px" width="40px" />
+                <Skeleton height="40px" borderRadius="6px" />
+              </Stack>
+            </Flex>
+
+            <Stack gap={2}>
+              <Skeleton height="14px" width="85px" />
+              <Skeleton height="80px" borderRadius="6px" />
+            </Stack>
+
+            <Stack gap={2}>
+              <Skeleton height="14px" width="120px" />
+              <Skeleton height="70px" borderRadius="6px" />
+            </Stack>
+
+          </Stack>
+        </DrawerBody>
         ) : (
           <form onSubmit={handleSubmit}>
             <DrawerBody

--- a/client/src/components/quota-tracking/QuotaDrawer.jsx
+++ b/client/src/components/quota-tracking/QuotaDrawer.jsx
@@ -19,6 +19,8 @@ import {
   useQuotaById,
   useUpdateQuota,
 } from "@/contexts/hooks/data-fetching/useQuotas";
+import { useProvidersSummary } from "@/contexts/hooks/data-fetching/useProviders";
+import { useLocations } from "@/contexts/hooks/data-fetching/useLocations";
 import { useCreateLog } from "@/contexts/hooks/data-fetching/useVersionLogs";
 import { useAuthContext } from "@/contexts/hooks/useAuthContext";
 import { useUserContext } from "@/contexts/hooks/useUserContext";
@@ -54,10 +56,14 @@ export default function QuotaDrawer({
   const btnRef = React.useRef();
   const userInfo = useUserContext();
   const [quota, setQuota] = useState(0);
-  const { data: quotaData, isLoading } = useQuotaById(
+  const { data: quotaData, isLoading: isQuotaByIdLoading } = useQuotaById(
     quotaID,
     isOpen && !!quotaID
   );
+  const { data: providers, isLoading: isProvidersLoading } = useProvidersSummary()
+  const { data: locationsData, isLoading: isLocationsLoading } = useLocations()
+  const locations = locationsData?.locations || [];
+  const isDrawerLoading = (quotaID ? isQuotaByIdLoading : false) || isProvidersLoading || isLocationsLoading;
   const { mutate: createQuota } = useCreateQuota();
   const { mutate: updateQuota } = useUpdateQuota();
   const {
@@ -304,7 +310,7 @@ export default function QuotaDrawer({
           </Text>
         </DrawerHeader>
 
-        {isLoading ? (
+        {isDrawerLoading ? (
           <SkeletonBody />
         ) : (
           <form onSubmit={handleSubmit}>
@@ -314,6 +320,7 @@ export default function QuotaDrawer({
               <Stack gap={4}>
                 {isLocked && <NotificationBanner action={action} />}
                 <ProviderDropdown
+                  providers={providers}
                   providerId={providerId}
                   setProviderId={setProviderId}
                   isLocked={isLocked}
@@ -337,6 +344,7 @@ export default function QuotaDrawer({
                 </Flex>
                 <Flex justify="space-between">
                   <LocationDropdown
+                    locations={locations}
                     locationId={locationId}
                     setLocationId={setLocationId}
                     isLocked={isLocked}

--- a/client/src/components/quota-tracking/QuotaDrawer.jsx
+++ b/client/src/components/quota-tracking/QuotaDrawer.jsx
@@ -326,7 +326,10 @@ export default function QuotaDrawer({
               </Stack>
               <Stack flex={1} gap={2}>
                 <Skeleton height="14px" width="55px" />
-                <Skeleton height="40px" borderRadius="6px" />
+                <Flex gap={2}>
+                  <Skeleton height="40px" borderRadius="6px" flex={1} />
+                  <Skeleton height="40px" borderRadius="6px" flex={1} />
+                </Flex>
               </Stack>
             </Flex>
 
@@ -348,7 +351,7 @@ export default function QuotaDrawer({
 
             <Stack gap={2}>
               <Skeleton height="14px" width="120px" />
-              <Skeleton height="70px" borderRadius="6px" />
+              <Skeleton height="120px" borderRadius="6px" />
             </Stack>
 
           </Stack>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -33,9 +33,9 @@ import CustomSelect from "@/components/common/CustomSelect";
 import { LockRightElement } from "../tools/shared";
 import { MdDeleteOutline } from "react-icons/md";
 
-export function LocationDropdown({ locationId, setLocationId, isLocked, isInvalid }) {
-  const { data: { locations = [] } = {}, isLoading: loadingLocations } =
-    useLocations();
+export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
+  // const { data: { locations = [] } = {}, isLoading: loadingLocations } =
+  //   useLocations();
   const createLocation = useCreateLocation();
   const deleteLocation = useDeleteLocation();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -52,20 +52,20 @@ export function LocationDropdown({ locationId, setLocationId, isLocked, isInvali
     }
   }, [isOpen]);
 
-  if (loadingLocations) {
-    return (
-      <FormControl w="50%">
-        <Skeleton
-          height="16px"
-          mb={2}
-        />
-        <Skeleton
-          height="40px"
-          borderRadius="6px"
-        />
-      </FormControl>
-    );
-  }
+  // if (loadingLocations) {
+  //   return (
+  //     <FormControl w="50%">
+  //       <Skeleton
+  //         height="16px"
+  //         mb={2}
+  //       />
+  //       <Skeleton
+  //         height="40px"
+  //         borderRadius="6px"
+  //       />
+  //     </FormControl>
+  //   );
+  // }
 
   const options = locations.map((l) => ({
     value: String(l.id),

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -15,7 +15,6 @@ import {
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
-  Skeleton,
   Spinner,
   Text,
   useDisclosure,
@@ -26,7 +25,6 @@ import { ChevronDown } from "lucide-react";
 import {
   useCreateLocation,
   useDeleteLocation,
-  useLocations,
 } from "@/contexts/hooks/data-fetching/useLocations";
 import CustomSelect from "@/components/common/CustomSelect";
 

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -34,8 +34,6 @@ import { LockRightElement } from "../tools/shared";
 import { MdDeleteOutline } from "react-icons/md";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
-  // const { data: { locations = [] } = {}, isLoading: loadingLocations } =
-  //   useLocations();
   const createLocation = useCreateLocation();
   const deleteLocation = useDeleteLocation();
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -51,21 +49,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       }, 0);
     }
   }, [isOpen]);
-
-  // if (loadingLocations) {
-  //   return (
-  //     <FormControl w="50%">
-  //       <Skeleton
-  //         height="16px"
-  //         mb={2}
-  //       />
-  //       <Skeleton
-  //         height="40px"
-  //         borderRadius="6px"
-  //       />
-  //     </FormControl>
-  //   );
-  // }
 
   const options = locations.map((l) => ({
     value: String(l.id),

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -4,30 +4,13 @@ import {
   FormErrorMessage,
   FormLabel,
   InputGroup,
-  Skeleton,
 } from "@chakra-ui/react";
 
 import CustomSelect from "@/components/common/CustomSelect";
-import { useProvidersSummary } from "@/contexts/hooks/data-fetching/useProviders";
 
 import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
-  // const { data: providers = [], isLoading: loadingSummary } =
-  //   useProvidersSummary();
-
-  // if (loadingSummary) {
-  //   return (
-  //     <>
-  //       <Skeleton
-  //         height="16px"
-  //         mb={2}
-  //       />
-  //       <Skeleton height="40px" />
-  //     </>
-  //   );
-  // }
-
   const options = providers.map((p) => ({
     value: String(p.id),
     label: p.name,

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -12,21 +12,21 @@ import { useProvidersSummary } from "@/contexts/hooks/data-fetching/useProviders
 
 import { LockRightElement } from "../tools/shared";
 
-export function ProviderDropdown({ providerId, setProviderId, isLocked, isInvalid }) {
-  const { data: providers = [], isLoading: loadingSummary } =
-    useProvidersSummary();
+export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
+  // const { data: providers = [], isLoading: loadingSummary } =
+  //   useProvidersSummary();
 
-  if (loadingSummary) {
-    return (
-      <>
-        <Skeleton
-          height="16px"
-          mb={2}
-        />
-        <Skeleton height="40px" />
-      </>
-    );
-  }
+  // if (loadingSummary) {
+  //   return (
+  //     <>
+  //       <Skeleton
+  //         height="16px"
+  //         mb={2}
+  //       />
+  //       <Skeleton height="40px" />
+  //     </>
+  //   );
+  // }
 
   const options = providers.map((p) => ({
     value: String(p.id),


### PR DESCRIPTION
## Description
- refactored quota drawer so that the drawer is the only source of truth for fetching data for provider dropdown and location dropdown
- allows there to be one unified loading skeleton for the quota drawer
- refactored skeleton for quota drawer to match higher fidelity and not use SkeletonBody component anymore

## Screenshots/Media
<img width="1710" height="985" alt="Screenshot 2026-04-16 at 4 08 08 PM" src="https://github.com/user-attachments/assets/426df3a3-78b8-4366-a785-84aad54ec8a4" />

## Issues
Closes #213 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified, high-fidelity loading skeleton to the quota drawer and centralizes provider/location fetching in the drawer. Addresses Linear #213 by removing flicker and making the sidebar load consistently.

- **Refactors**
  - Fetches providers via `useProvidersSummary` and locations via `useLocations` in `QuotaDrawer`.
  - Adds a single `isDrawerLoading` gate and replaces `SkeletonBody` with a detailed `Skeleton` layout.
  - Updates `ProviderDropdown` and `LocationDropdown` to accept `providers`/`locations` as props, removing internal fetching/loading and unused imports.

<sup>Written for commit 3e40465646d906503e8e8728a5d88ea1d0e62a9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

