### PR TITLE
217 settings improvements

### DIFF
--- a/client/src/components/user-settings/PersonalInfo.jsx
+++ b/client/src/components/user-settings/PersonalInfo.jsx
@@ -30,7 +30,7 @@ const ROLE_LABELS = {
   master: "Master",
 };
 
-export default function PersonalInfo() {
+export default function PersonalInfo({activeEditingKey, setActiveEditingKey}) {
   const userData = useUserContext();
   const { currentUser } = useAuthContext();
   const { mutateAsync: update } = useUpdateUser();
@@ -98,10 +98,15 @@ export default function PersonalInfo() {
         onOpen();
       } else {
         setEditing((prev) => ({ ...prev, [key]: false }));
+        setActiveEditingKey(null);
       }
     } else {
+      // Prevents editing if another field is being edited
+      if (activeEditingKey && activeEditingKey !== key) return;
+
       setEditing((prev) => ({ ...prev, [key]: true }));
       setEditingKey(key);
+      setActiveEditingKey(key);
     }
   };
 
@@ -211,7 +216,7 @@ export default function PersonalInfo() {
                     aria-label={isEditMode ? `Save ${label}` : `Edit ${label}`}
                     onClick={() => toggleEdit(key)}
                     flexShrink={0}
-                    disabled={editingKey && editingKey !== key}
+                    disabled={activeEditingKey && activeEditingKey !== key}
                   />
                 )}
               </Flex>

--- a/client/src/components/user-settings/PersonalInfo.jsx
+++ b/client/src/components/user-settings/PersonalInfo.jsx
@@ -51,6 +51,7 @@ export default function PersonalInfo() {
     email: false,
     role: false,
   });
+  const [editingKey, setEditingKey] = useState("");
 
   useEffect(() => {
     if (dbUser) {
@@ -92,6 +93,7 @@ export default function PersonalInfo() {
   const toggleEdit = (key) => {
     if (editing[key]) {
       setPendingKey(key);
+      setEditingKey("");
       if (userInfo[key] !== dbUser[key]) {
         onOpen();
       } else {
@@ -99,6 +101,7 @@ export default function PersonalInfo() {
       }
     } else {
       setEditing((prev) => ({ ...prev, [key]: true }));
+      setEditingKey(key);
     }
   };
 
@@ -208,6 +211,7 @@ export default function PersonalInfo() {
                     aria-label={isEditMode ? `Save ${label}` : `Edit ${label}`}
                     onClick={() => toggleEdit(key)}
                     flexShrink={0}
+                    disabled={editingKey && editingKey !== key}
                   />
                 )}
               </Flex>

--- a/client/src/components/user-settings/PersonalInfo.jsx
+++ b/client/src/components/user-settings/PersonalInfo.jsx
@@ -84,6 +84,7 @@ export default function PersonalInfo({activeEditingKey, setActiveEditingKey}) {
       });
       await refetch();
       setEditing((prev) => ({ ...prev, [pendingKey]: false }));
+      setActiveEditingKey(null)
       return true;
     } catch (_error) {
       return false;

--- a/client/src/components/user-settings/PersonalInfo.jsx
+++ b/client/src/components/user-settings/PersonalInfo.jsx
@@ -65,8 +65,9 @@ export default function PersonalInfo() {
 
   if (!dbUser) return null;
 
-  const updateUserProp = (key, value) =>
+  const updateUserProp = (key, value) => {
     setUserInfo((prev) => ({ ...prev, [key]: value }));
+  }
 
   const handleSave = async () => {
     if (!dbUser?.id) return false;
@@ -91,7 +92,11 @@ export default function PersonalInfo() {
   const toggleEdit = (key) => {
     if (editing[key]) {
       setPendingKey(key);
-      onOpen();
+      if (userInfo[key] !== dbUser[key]) {
+        onOpen();
+      } else {
+        setEditing((prev) => ({ ...prev, [key]: false }));
+      }
     } else {
       setEditing((prev) => ({ ...prev, [key]: true }));
     }

--- a/client/src/components/user-settings/QuotaCalcFactor.jsx
+++ b/client/src/components/user-settings/QuotaCalcFactor.jsx
@@ -19,7 +19,7 @@ import { MdEdit } from "react-icons/md";
 
 import ConfirmationModal from "./ConfirmationModal";
 
-export default function QuotaCalcFactor() {
+export default function QuotaCalcFactor({activeEditingKey, setActiveEditingKey}) {
   const userData = useUserContext();
   const { mutateAsync: updateUser } = useUpdateUser();
   const dbUser = userData?.dbUser;
@@ -65,9 +65,12 @@ export default function QuotaCalcFactor() {
         onOpen();
       } else {
         setIsEditMode(false);
+        setActiveEditingKey(null);
       }
     } else {
+      if (activeEditingKey && activeEditingKey !== "quotaFactor") return;
       setIsEditMode(true);
+      setActiveEditingKey("quotaFactor");
     }
   };
 
@@ -134,6 +137,7 @@ export default function QuotaCalcFactor() {
             }
             onClick={handleToggle}
             flexShrink={0}
+            disabled={activeEditingKey && activeEditingKey !== "quotaFactor"}
           />
         </Flex>
       </FormControl>

--- a/client/src/components/user-settings/QuotaCalcFactor.jsx
+++ b/client/src/components/user-settings/QuotaCalcFactor.jsx
@@ -50,6 +50,7 @@ export default function QuotaCalcFactor({activeEditingKey, setActiveEditingKey})
       });
       await refetch();
       setIsEditMode(false);
+      setActiveEditingKey(null);
       return true;
     } catch (_error) {
       return false;

--- a/client/src/components/user-settings/QuotaCalcFactor.jsx
+++ b/client/src/components/user-settings/QuotaCalcFactor.jsx
@@ -29,6 +29,7 @@ export default function QuotaCalcFactor() {
   const [factor, setFactor] = useState(
     dbUser?.apptCalcFactor?.toString() || ""
   );
+  
   const [isEditMode, setIsEditMode] = useState(false);
 
   useEffect(() => {
@@ -57,7 +58,14 @@ export default function QuotaCalcFactor() {
 
   const handleToggle = () => {
     if (isEditMode) {
-      onOpen();
+      const currentNum = factor === "" ? 0 : parseFloat(factor);
+      const originalNum = dbUser?.apptCalcFactor || 0;
+
+      if (currentNum !== originalNum) {
+        onOpen();
+      } else {
+        setIsEditMode(false);
+      }
     } else {
       setIsEditMode(true);
     }

--- a/client/src/components/user-settings/Settings.jsx
+++ b/client/src/components/user-settings/Settings.jsx
@@ -1,4 +1,5 @@
 import { Avatar, Box, Grid, GridItem, Text, useDisclosure } from "@chakra-ui/react";
+import { useState } from "react";
 
 import { useAuthContext } from "@/contexts/hooks/useAuthContext";
 import { useUserContext } from "@/contexts/hooks/useUserContext";
@@ -17,6 +18,7 @@ export function Settings() {
   const userData = useUserContext();
   const dbUser = userData?.dbUser;
   const { currentUser } = useAuthContext();
+  const [activeEditingKey, setActiveEditingKey] = useState(null);
 
   return (
     <Box
@@ -98,7 +100,10 @@ export function Settings() {
           borderColor="gray.200"
           marginBottom="30px"
         >
-          <PersonalInfo />
+          <PersonalInfo
+            activeEditingKey={activeEditingKey}
+            setActiveEditingKey={setActiveEditingKey}
+          />
         </GridItem>
 
         {dbUser?.role === "master" || dbUser?.role === "ccm" ? (
@@ -129,7 +134,10 @@ export function Settings() {
               ml="45px"
               borderColor="gray.200"
             >
-              <QuotaCalcFactor />
+              <QuotaCalcFactor
+                activeEditingKey={activeEditingKey}
+                setActiveEditingKey={setActiveEditingKey}
+              />
             </GridItem>
           </>
         ) : (


### PR DESCRIPTION
## Description
Basic logic fixes to implement better flow for personal info modification in the settings page.

## Screenshots/Media
<img width="1311" height="182" alt="image" src="https://github.com/user-attachments/assets/f193d127-e1ed-4baa-8d23-cb3b32bb6ed7" />

## Issues
Closes #217

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Settings flow by centralizing edit state with an `activeEditingKey` so only one field across Personal Info and the quota calculation factor can be edited at a time (other edit buttons are disabled). Confirmation modals now open only when a value changed; edit icons re-enable correctly after save/cancel or no-change exits, fixing the disabled-icon bug and closing #217.

<sup>Written for commit 08e5585a0b8cce6f705dbd8b085865c81e2c53d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

