### PR TITLE
218 provider directory improvements

### DIFF
--- a/client/src/components/provider-directory/ProviderDirectoryPage.jsx
+++ b/client/src/components/provider-directory/ProviderDirectoryPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { AnimatePresence, motion } from "framer-motion";
 
@@ -29,6 +29,18 @@ export const ProviderDirectoryPage = () => {
   const [drawerMode, setDrawerMode] = useState("create");
   const [selectedProvider, setSelectedProvider] = useState(null);
   const [manageOpen, setManageOpen] = useState(false);
+  const manageRef = useRef(null);
+
+  useEffect(() => {
+    if (!manageOpen) return;
+    const handleClickOutside = (e) => {
+      if (manageRef.current && !manageRef.current.contains(e.target)) {
+        setManageOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [manageOpen]);
 
   const debouncedProviderQuery = useDebounce(
     (value) => setProviderQuery(value),
@@ -96,7 +108,7 @@ export const ProviderDirectoryPage = () => {
             isLoading={roleLoading}
           />
           {(role === "ccm" || role === "master") && (
-            <Box position="relative">
+            <Box position="relative" ref={manageRef}>
               <Button
                 bg="#113D64"
                 color="white"


### PR DESCRIPTION
## Description
- changed the manage button so that it closes off when clicking outside of it
- also checked for when clicking a provider row

## Screenshots/Media
<img width="565" height="477" alt="Screenshot 2026-04-17 at 5 54 26 PM" src="https://github.com/user-attachments/assets/ece44bca-6353-416f-88d4-a5f105710f78" />


<img width="601" height="427" alt="Screenshot 2026-04-17 at 5 54 03 PM" src="https://github.com/user-attachments/assets/92ba2dc2-4c15-477a-a01a-14b09347e706" />

## Issues
Closes #218 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Provider Directory “Manage” menu close when clicking anywhere outside it, including on provider rows. Improves UX and meets Linear #218.

- **Bug Fixes**
  - Added outside-click handler using `useRef` and `useEffect` to close the Manage dropdown on `mousedown` outside its container.

<sup>Written for commit df1e8c443b299ba3a93336ee04bda2adef81dcd5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

