### PR TITLE
202 quota card fixing

### DIFF
--- a/client/src/components/quota-tracking/QuotaTrackingPage.jsx
+++ b/client/src/components/quota-tracking/QuotaTrackingPage.jsx
@@ -103,6 +103,7 @@ export const QuotaTracking = () => {
         totalProgress: 0,
         totalQuota: 0,
         rate: 0,
+        differentLocations: 0,
         activeProviders: 0,
         needsAttention: 0,
       };


### PR DESCRIPTION
## Description
when there are no quotas, the quota card no longer displays undefined locations

## Screenshots/Media
<img width="376" height="195" alt="image" src="https://github.com/user-attachments/assets/1f366f53-50d6-4378-b183-3d40803450e8" />


## Issues
Closes #202 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the quota card to stop showing undefined locations when no quotas exist by defaulting differentLocations to 0. Closes #202.

<sup>Written for commit 265c62585e99d517a445efd8bdcdec427f21c573. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

