### PR TITLE
201 provider long term notes

### DIFF
--- a/client/src/components/common/TextPopup.jsx
+++ b/client/src/components/common/TextPopup.jsx
@@ -20,10 +20,11 @@ const TextPopup = ({ text = "", alwaysShowPopup = false, truncateAt }) => {
         <Box
           maxWidth="100px"
           cursor="pointer"
-          onClick={(e) => {
+          onDoubleClick={(e) => {
             e.stopPropagation();
-            setIsOpen((prev) => !prev);
+            setIsOpen(true);
           }}
+          onClick={(e) => e.stopPropagation()}
         >
           <Text
             isTruncated

--- a/client/src/components/common/TextPopup.jsx
+++ b/client/src/components/common/TextPopup.jsx
@@ -1,29 +1,29 @@
 import { useState } from "react";
 
-import {
-  Box,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger,
-  Portal,
-  Text,
-} from "@chakra-ui/react";
+
+
+import { Box, Popover, PopoverArrow, PopoverBody, PopoverContent, PopoverTrigger, Portal, Text } from "@chakra-ui/react";
+
+
+
+
 
 const TextPopup = ({ text = "", alwaysShowPopup = false, truncateAt }) => {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <Popover isOpen={isOpen} onClose={() => setIsOpen(false)}>
+    <Popover
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+    >
       <PopoverTrigger>
         <Box
           maxWidth="100px"
-          onDoubleClick={(e) => {
+          cursor="pointer"
+          onClick={(e) => {
             e.stopPropagation();
-            setIsOpen(true);
+            setIsOpen((prev) => !prev);
           }}
-          onClick={(e) => e.stopPropagation()}
         >
           <Text
             isTruncated

--- a/client/src/components/provider-directory/ProviderTable.jsx
+++ b/client/src/components/provider-directory/ProviderTable.jsx
@@ -1,26 +1,19 @@
 import { useEffect, useRef, useState } from "react";
 
-import {
-  Box,
-  Button,
-  Skeleton,
-  Table,
-  TableContainer,
-  Tag,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-  Wrap,
-  WrapItem,
-} from "@chakra-ui/react";
+
+
 import { AddIcon } from "@chakra-ui/icons";
-import { MdPersonAdd } from "react-icons/md";
+import { Box, Button, Skeleton, Table, TableContainer, Tag, Tbody, Td, Text, Th, Thead, Tr, Wrap, WrapItem } from "@chakra-ui/react";
+
+
 
 import TextPopup from "@/components/common/TextPopup";
 import { useTags } from "@/contexts/hooks/data-fetching/useTags";
+import { MdPersonAdd } from "react-icons/md";
+
+
+
+
 
 const SELECTED_BG = "#EDF2F7";
 
@@ -155,10 +148,10 @@ export default function ProviderTable({
     if (isMissing) {
       // Defaults per inputType
       if (cat.inputType === "tag")
-        return <Text 
-        color="gray.400" 
-        fontFamily={"Inter"} 
-        fontSize={"14px"} 
+        return <Text
+        color="gray.400"
+        fontFamily={"Inter"}
+        fontSize={"14px"}
         fontStyle={"normal"}
         fontWeight={"400"}
         lineHeight={"22px"}>
@@ -255,8 +248,14 @@ export default function ProviderTable({
         borderBottom="1px solid"
         borderColor="gray.200"
         cursor={onProviderDoubleClick ? "pointer" : "default"}
-        sx={isSelected ? { background: `${SELECTED_BG} !important` } : undefined}
-        _hover={onProviderDoubleClick ? { bg: isSelected ? SELECTED_BG : "gray.50" } : {}}
+        sx={
+          isSelected ? { background: `${SELECTED_BG} !important` } : undefined
+        }
+        _hover={
+          onProviderDoubleClick
+            ? { bg: isSelected ? SELECTED_BG : "gray.50" }
+            : {}
+        }
         onClick={() => {
           if (!onProviderDoubleClick) return;
           if (selectedRowId === provider.id) {
@@ -275,7 +274,8 @@ export default function ProviderTable({
             lineHeight="22px"
             color="#113D64"
           >
-            {provider.name ?? ""}{provider.degree ? `, ${provider.degree}` : ""}
+            {provider.name ?? ""}
+            {provider.degree ? `, ${provider.degree}` : ""}
           </Text>
           {provider.phoneNumber && (
             <Text
@@ -316,16 +316,23 @@ export default function ProviderTable({
         </Td>
         {dynamicCells}
         <Td {...fixedTdProps}>
-          <Text
-            fontFamily="Inter"
-            fontSize="14px"
-            fontStyle="normal"
-            fontWeight="400"
-            lineHeight="22px"
-            color="#113D64"
-          >
-            {provider.notes ?? ""}
-          </Text>
+          {provider.notes && provider.notes.length > 100 ? (
+            <TextPopup
+              text={provider.notes}
+              truncateAt={100}
+            />
+          ) : (
+            <Text
+              fontFamily="Inter"
+              fontSize="14px"
+              fontStyle="normal"
+              fontWeight="400"
+              lineHeight="22px"
+              color="#113D64"
+            >
+              {provider.notes ?? ""}
+            </Text>
+          )}
         </Td>
       </Tr>
     );


### PR DESCRIPTION
## Description
Simplify long text using TextPopup in the Provider Directory and Quota Tracking pages. 

## Screenshots/Media
<img width="1470" height="796" alt="image" src="https://github.com/user-attachments/assets/a8602031-bb77-4b96-9e94-f34e90d04374" />

## Issues
Closes #201

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate long provider notes in the Provider Directory and show full text in a popover that opens on double-click and closes on single click. Addresses #201 by making long-term notes easier to scan without table overflow.

- **New Features**
  - Provider notes: truncate at 100 chars; double-click to open a popover with the full note (double-clicks don’t trigger row actions).
  - TextPopup: double-click to open, click to close; add pointer cursor and minor cleanup for reuse across pages.

<sup>Written for commit 9cbc9c9b6a23c115e7d84b08009549f3031871e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

