### PR TITLE
214 cls

### DIFF
--- a/client/src/components/provider-directory/ProviderTable.jsx
+++ b/client/src/components/provider-directory/ProviderTable.jsx
@@ -24,18 +24,28 @@ import { useTags } from "@/contexts/hooks/data-fetching/useTags";
 
 const SELECTED_BG = "#EDF2F7";
 
+const skeletonThProps = {
+  fontFamily: "Inter",
+  fontSize: "12px",
+  fontStyle: "normal",
+  fontWeight: "700",
+  lineHeight: "16px",
+  letterSpacing: "0.6px",
+  padding: "15px 25px",
+  backgroundColor: "#C8D4E6",
+  color: "#113D64",
+  borderRight: "1px solid",
+  borderColor: "gray.200",
+};
+
 const SkeletonHeader = () => {
   return (
-    <Thead>
+    <Thead bg="#C8D4E6" h="40px" position="sticky" top={0} zIndex={1}>
       <Tr>
-        {Array.from({ length: 4 }, (_, i) => (
-          <Th
-            key={i}
-            p={0}
-          >
-            <Skeleton height="60px" />
-          </Th>
-        ))}
+        <Th {...skeletonThProps}>Provider</Th>
+        <Th {...skeletonThProps}>NPI/License</Th>
+        <Th {...skeletonThProps}>&nbsp;</Th>
+        <Th {...skeletonThProps} borderRight="none">Long Term Notes</Th>
       </Tr>
     </Thead>
   );
@@ -44,23 +54,25 @@ const SkeletonHeader = () => {
 const SkeletonBody = () => {
   return (
     <Tbody>
-      {Array.from({ length: 5 }, (_, i) => (
+      {Array.from({ length: 15 }, (_, i) => (
         <Tr
           key={i}
           borderBottom="1px solid"
           borderColor="gray.200"
+          bg={i % 2 === 0 ? "white" : "#F9F9F9"}
         >
-          <Td>
-            <Skeleton height="40px" />
+          <Td borderRight="1px solid" borderColor="gray.200" padding="16px 24px">
+            <Skeleton height="20px" width={`${50 + (i * 13) % 35}%`} mb={1} />
+            <Skeleton height="14px" width="40%" />
           </Td>
-          <Td>
-            <Skeleton height="40px" />
+          <Td borderRight="1px solid" borderColor="gray.200" padding="16px 24px">
+            <Skeleton height="20px" width={`${40 + (i * 11) % 30}%`} />
           </Td>
-          <Td>
-            <Skeleton height="40px" />
+          <Td borderRight="1px solid" borderColor="gray.200" padding="16px 24px">
+            <Skeleton height="24px" width="80px" borderRadius="6px" />
           </Td>
-          <Td>
-            <Skeleton height="40px" />
+          <Td padding="16px 24px">
+            <Skeleton height="20px" width={`${30 + (i * 17) % 50}%`} />
           </Td>
         </Tr>
       ))}
@@ -348,6 +360,7 @@ export default function ProviderTable({
       borderColor="gray.200"
       borderRadius="lg"
       overflowY="auto"
+      minH="calc(100vh - 300px)"
     >
       <Table
         sx={{

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -24,15 +24,34 @@ import QuotaDrawer from "@/components/quota-tracking/QuotaDrawer";
 const SELECTED_BG = "#EDF2F7";
 
 const SkeletonRows = () => {
+  const tdProps = {
+    borderRight: "1px solid",
+    borderColor: "gray.200",
+    padding: "16px 24px",
+    gap: "10px",
+  };
   return (
     <>
       {Array.from({ length: 15 }, (_, i) => (
         <Tr key={i} borderBottom="1px solid" borderColor="gray.200">
-          {Array.from({ length: 5 }, (_, j) => (
-            <Td key={j} borderRight="1px solid" borderColor="gray.200">
-              <Skeleton height="20px" width={j === 3 ? "100%" : `${60 + (i * 13 + j * 17) % 30}%`} />
-            </Td>
-          ))}
+          <Td {...tdProps}>
+            <Skeleton height="20px" width={`${55 + (i * 11) % 30}%`} />
+          </Td>
+          <Td {...tdProps}>
+            <Skeleton height="28px" width={`${70 + (i * 13) % 25}px`} borderRadius="6px" />
+          </Td>
+          <Td {...tdProps}>
+            <Skeleton height="28px" width="80px" borderRadius="6px" />
+          </Td>
+          <Td {...tdProps}>
+            <Box>
+              <Skeleton height="8px" width="100%" borderRadius="full" mb={1} />
+              <Skeleton height="12px" width="50%" />
+            </Box>
+          </Td>
+          <Td {...tdProps} borderRight="none">
+            <Skeleton height="20px" width={`${40 + (i * 17) % 40}%`} />
+          </Td>
         </Tr>
       ))}
     </>

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -26,11 +26,11 @@ const SELECTED_BG = "#EDF2F7";
 const SkeletonRows = () => {
   return (
     <>
-      {Array.from({ length: 5 }, (_, i) => (
+      {Array.from({ length: 15 }, (_, i) => (
         <Tr key={i} borderBottom="1px solid" borderColor="gray.200">
           {Array.from({ length: 5 }, (_, j) => (
             <Td key={j} borderRight="1px solid" borderColor="gray.200">
-              <Skeleton height="40px" />
+              <Skeleton height="20px" width={j === 3 ? "100%" : `${60 + (i * 13 + j * 17) % 30}%`} />
             </Td>
           ))}
         </Tr>
@@ -113,6 +113,7 @@ const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
       borderColor="gray.200"
       borderRadius="lg"
       overflowY="auto"
+      minH="calc(100vh - 480px)"
     >
       <Table
         sx={{

--- a/client/src/components/quota-tracking/QuotaTrackingPage.jsx
+++ b/client/src/components/quota-tracking/QuotaTrackingPage.jsx
@@ -30,9 +30,8 @@ import QuotaTable from "./QuotaTable";
 const SkeletonCard = () => {
   return (
     <Card
-      height="12rem"
-      width="14rem"
-      flexShrink={1}
+      height="172.826px"
+      flex={1}
       borderWidth="1px"
       borderColor="gray.200"
       borderRadius="lg"
@@ -40,24 +39,13 @@ const SkeletonCard = () => {
       _hover={{ boxShadow: "md" }}
       transition="box-shadow 0.2s ease"
     >
-      <CardHeader pb={1}>
-        <Box
-          fontSize="sm"
-          color="gray.500"
-          fontWeight="medium"
-        >
-          <Skeleton height="10px" />
-        </Box>
+      <CardHeader pb="9px">
+        <Skeleton height="16px" width="60%" />
       </CardHeader>
 
-      <CardBody py={2}>
-        <Box
-          fontSize="3xl"
-          fontWeight="semibold"
-          color="gray.900"
-        >
-          <Skeleton height="20px" />
-        </Box>
+      <CardBody py={0}>
+        <Skeleton height="36px" width="50%" mb={2} />
+        <Skeleton height="14px" width="40%" />
       </CardBody>
     </Card>
   );

--- a/client/src/components/user-directory/UserPendingStatusList.jsx
+++ b/client/src/components/user-directory/UserPendingStatusList.jsx
@@ -27,6 +27,9 @@ const RequestSkeleton = () => {
     <Flex
       align="center"
       justify="space-between"
+      borderTop="1px solid #E2E8F0"
+      borderRadius="md"
+      p={3}
     >
       <HStack
         spacing={3}
@@ -39,11 +42,11 @@ const RequestSkeleton = () => {
           spacing={2}
         >
           <Skeleton
-            height="18px"
+            height="16px"
             width="160px"
           />
           <Skeleton
-            height="12px"
+            height="14px"
             width="220px"
           />
         </VStack>
@@ -55,14 +58,14 @@ const RequestSkeleton = () => {
           width="110px"
         />
         <Skeleton
-          height="32px"
-          width="110px"
-          borderRadius="md"
+          height="41px"
+          width="113px"
+          borderRadius="6px"
         />
         <Skeleton
-          height="32px"
-          width="110px"
-          borderRadius="md"
+          height="41px"
+          width="113px"
+          borderRadius="6px"
         />
       </HStack>
     </Flex>
@@ -118,7 +121,6 @@ export const UserPendingStatusList = ({ showAll = false }) => {
       >
         {isLoading ? (
           <>
-            <RequestSkeleton />
             <RequestSkeleton />
             <RequestSkeleton />
           </>

--- a/client/src/components/user-directory/UserTable.jsx
+++ b/client/src/components/user-directory/UserTable.jsx
@@ -81,21 +81,19 @@ const tdTextProps = {
 
 const SkeletonRows = () => (
   <>
-    {Array.from({ length: 5 }, (_, i) => (
+    {Array.from({ length: 15 }, (_, i) => (
       <Tr key={i} borderBottom="1px solid" borderColor="gray.200">
-        <Td borderRight="1px solid" borderColor="gray.200">
-          <Skeleton height="20px" />
+        <Td {...tdProps}>
+          <Skeleton height="20px" width={`${55 + (i * 11) % 30}%`} />
         </Td>
-        <Td borderRight="1px solid" borderColor="gray.200">
-          <Skeleton height="20px" />
+        <Td {...tdProps}>
+          <Skeleton height="20px" width={`${50 + (i * 17) % 35}%`} />
         </Td>
-        <Td borderRight="1px solid" borderColor="gray.200">
-          <Skeleton height="20px" />
+        <Td {...tdProps} textAlign="center">
+          <Skeleton height="22px" width="60px" borderRadius="6px" mx="auto" />
         </Td>
-        <Td>
-          <HStack>
-            <Skeleton boxSize="30px" borderRadius="md" />
-          </HStack>
+        <Td {...tdProps} borderRight="none" w="90px">
+          <Skeleton boxSize="30px" borderRadius="16px" />
         </Td>
       </Tr>
     ))}
@@ -131,6 +129,7 @@ export default function UserTable({
         borderColor="gray.200"
         borderRadius="lg"
         overflowY="auto"
+        minH="calc(100vh - 540px)"
       >
         <Table
           sx={{

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -29,10 +29,13 @@ const SkeletonRows = () => {
             <Skeleton height="20px" width={`${50 + (i * 13) % 35}%`} />
           </Td>
           <Td {...tdProps}>
-            <Skeleton height="20px" width="80px" />
+            <Box display="flex" gap="4px" alignItems="center">
+              <Skeleton height="20px" width="46px" />
+              <Skeleton height="20px" width="24px" />
+            </Box>
           </Td>
           <Td {...tdProps}>
-            <Skeleton height="20px" width="140px" />
+            <Skeleton height="20px" width="148px" />
           </Td>
           <Td {...tdProps} borderRight="none">
             <Skeleton height="20px" width={`${40 + (i * 17) % 40}%`} />

--- a/client/src/components/version-log/VersionLogTable.jsx
+++ b/client/src/components/version-log/VersionLogTable.jsx
@@ -19,21 +19,24 @@ import { MdSentimentDissatisfied } from "react-icons/md";
 const SkeletonRows = () => {
   return (
     <>
-      {Array.from({ length: 5 }, (_, i) => (
+      {Array.from({ length: 15 }, (_, i) => (
         <Tr
           key={i}
           borderBottom="1px solid"
           borderColor="gray.200"
         >
-          {Array.from({ length: 4 }, (_, j) => (
-            <Td
-              key={j}
-              borderRight="1px solid"
-              borderColor="gray.200"
-            >
-              <Skeleton height="40px" />
-            </Td>
-          ))}
+          <Td {...tdProps}>
+            <Skeleton height="20px" width={`${50 + (i * 13) % 35}%`} />
+          </Td>
+          <Td {...tdProps}>
+            <Skeleton height="20px" width="80px" />
+          </Td>
+          <Td {...tdProps}>
+            <Skeleton height="20px" width="140px" />
+          </Td>
+          <Td {...tdProps} borderRight="none">
+            <Skeleton height="20px" width={`${40 + (i * 17) % 40}%`} />
+          </Td>
         </Tr>
       ))}
     </>
@@ -81,6 +84,7 @@ const VersionLogTable = ({ loading, logs }) => {
         borderColor="gray.200"
         borderRadius="lg"
         overflowY="auto"
+        minH="calc(100vh - 280px)"
       >
         <Table
           sx={{


### PR DESCRIPTION
## Description

Created a skeleton with higher fidelity that mirrored the actual UI components

## Screenshots/Media

<img width="1506" height="817" alt="image" src="https://github.com/user-attachments/assets/4f43787f-a67c-4a90-9b14-53bb1aeb190f" />

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked loading skeletons across provider, quota, user, and version log views to mirror the final UI and reduce layout shift. Adds sticky headers and stable table heights for smoother loading.

- **UI Improvements**
  - Provider directory: header skeleton matches columns; sticky header; alternating row backgrounds.
  - Quota tracking: detailed cell skeletons including progress and action chips; updated metric card skeletons.
  - User directory: refined table and pending-list skeletons (badges/buttons, borders, spacing).
  - Version log: column-specific skeletons for version, tags, date, and notes.
  - Global: increased skeleton rows to 15 and added minH to tables to prevent CLS and flicker.

<sup>Written for commit c55941a087600844b0976e41fd52facd35386159. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

