### PR TITLE
feat: search function in provider/location for quota drawer

### DIFF
--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { AddIcon, CheckIcon } from "@chakra-ui/icons";
+import { CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -11,7 +11,6 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Spinner,
   Text,
   useDisclosure,
   useOutsideClick,
@@ -20,18 +19,13 @@ import {
 import { ChevronDown } from "lucide-react";
 import { MdDeleteOutline } from "react-icons/md";
 
-import {
-  useCreateLocation,
-  useDeleteLocation,
-} from "@/contexts/hooks/data-fetching/useLocations";
+import { useDeleteLocation } from "@/contexts/hooks/data-fetching/useLocations";
 import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
-  const createLocation = useCreateLocation();
   const deleteLocation = useDeleteLocation();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [newValue, setNewValue] = useState("");
   const [deletingMap, setDeletingMap] = useState({});
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -67,26 +61,10 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
     handleClose();
   };
 
-  const handleCreate = async (e) => {
-    e.stopPropagation();
-    const trimmed = newValue.trim();
-    if (!trimmed) return;
-
-    try {
-      const result = await createLocation.mutateAsync({ tagValue: trimmed });
-      const newLocation = Array.isArray(result) ? result[0] : result;
-      if (newLocation?.id) setLocationId(newLocation.id);
-      setNewValue("");
-      handleClose();
-    } catch (_err) {
-      toast({
-        title: "Error",
-        description: "Failed to create location",
-        status: "error",
-        position: "bottom-right",
-        duration: 5000,
-        isClosable: true,
-      });
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" && filteredLocations.length > 0) {
+      e.preventDefault();
+      handleSelect(filteredLocations[0].id);
     }
   };
 
@@ -162,7 +140,9 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
               value={isOpen ? searchQuery : (selectedLocation?.tagValue ?? "")}
               onChange={handleInputChange}
               onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
+              onKeyDown={handleKeyDown}
               placeholder="Select location"
+              autoComplete="off"
               cursor={isOpen ? "text" : "pointer"}
               readOnly={!isOpen}
               fontFamily="Inter"
@@ -260,42 +240,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                   </Text>
                 )}
               </Box>
-              <HStack
-                px={3}
-                py={2}
-                gap={2}
-                borderTop="1px solid"
-                borderColor="gray.100"
-              >
-                <Input
-                  placeholder="Enter location"
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  fontFamily="Inter"
-                  fontStyle="normal"
-                  lineHeight="20px"
-                  fontSize="12px"
-                  fontWeight="400"
-                  color="black"
-                  border="1px solid var(--gray-200, #E2E8F0)"
-                  borderRadius="4px"
-                  h="30px"
-                  padding="10px"
-                  _placeholder={{ color: "#A0AEC0" }}
-                />
-                <Button
-                  size="xs"
-                  onClick={handleCreate}
-                  isDisabled={createLocation.isPending}
-                  variant="ghost"
-                  _hover={{ bg: "none" }}
-                  _active={{ bg: "none" }}
-                >
-                  {createLocation.isPending ? <Spinner size="xs" /> : <AddIcon />}
-                </Button>
-              </HStack>
             </Box>
           )}
         </Box>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -271,7 +271,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                   placeholder="Enter location"
                   value={newValue}
                   onChange={(e) => setNewValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") handleCreate(e); }}
+                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
                   onMouseDown={(e) => e.stopPropagation()}
                   fontFamily="Inter"
                   fontStyle="normal"

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 
-import { AddIcon } from "@chakra-ui/icons";
+import { AddIcon, CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -10,26 +10,22 @@ import {
   HStack,
   Input,
   InputGroup,
-  Menu,
-  MenuButton,
-  MenuItemOption,
-  MenuList,
-  MenuOptionGroup,
+  InputRightElement,
   Spinner,
   Text,
   useDisclosure,
+  useOutsideClick,
   useToast,
 } from "@chakra-ui/react";
 import { ChevronDown } from "lucide-react";
+import { MdDeleteOutline } from "react-icons/md";
 
 import {
   useCreateLocation,
   useDeleteLocation,
 } from "@/contexts/hooks/data-fetching/useLocations";
-import CustomSelect from "@/components/common/CustomSelect";
-
+import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
-import { MdDeleteOutline } from "react-icons/md";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
   const createLocation = useCreateLocation();
@@ -37,24 +33,39 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [newValue, setNewValue] = useState("");
   const [deletingMap, setDeletingMap] = useState({});
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const toast = useToast();
-  const selectedItemRef = useRef(null);
+  const containerRef = useRef(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(() => {
-        selectedItemRef.current?.scrollIntoView({ block: "nearest" });
-      }, 0);
-    }
-  }, [isOpen]);
+  const debouncedSetSearch = useDebounce((val) => setDebouncedSearch(val), 300);
 
-  const options = locations.map((l) => ({
-    value: String(l.id),
-    label: l.tagValue,
-  }));
+  const handleClose = () => {
+    setSearchQuery("");
+    setDebouncedSearch("");
+    onClose();
+  };
+
+  useOutsideClick({ ref: containerRef, handler: handleClose });
+
   const selectedLocation = locations.find(
     (location) => String(location.id) === String(locationId)
   );
+
+  const filteredLocations = locations.filter((l) =>
+    l.tagValue.toLowerCase().includes(debouncedSearch.toLowerCase())
+  );
+
+  const handleInputChange = (e) => {
+    const val = e.target.value;
+    setSearchQuery(val);
+    debouncedSetSearch(val);
+  };
+
+  const handleSelect = (id) => {
+    setLocationId(id);
+    handleClose();
+  };
 
   const handleCreate = async (e) => {
     e.stopPropagation();
@@ -66,7 +77,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       const newLocation = Array.isArray(result) ? result[0] : result;
       if (newLocation?.id) setLocationId(newLocation.id);
       setNewValue("");
-      onClose();
+      handleClose();
     } catch (_err) {
       toast({
         title: "Error",
@@ -142,93 +153,136 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
           <LockRightElement />
         </InputGroup>
       ) : (
-        <Menu
-          closeOnSelect={true}
-          isOpen={isOpen}
-          onOpen={onOpen}
-          onClose={onClose}
-          matchWidth
+        <Box
+          ref={containerRef}
+          position="relative"
         >
-          <MenuButton
-            as={Button}
-            variant="outline"
-            w="100%"
-            justifyContent="flex-start"
-            textAlign="left"
-            rightIcon={<ChevronDown size={20} />}
-            color={"var(--gray-700, #2D3748)"}
-            fontFamily={"Inter"}
-            fontSize={"14px"}
-            fontWeight={"400"}
-            lineHeight={"20px"}
-            fontStyle={"normal"}
-            borderRadius={"4px"}
-            border={isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)"}
-            background={"var(--white, #FFF)"}
-          >
-            {selectedLocation?.tagValue
-              ? selectedLocation.tagValue.length > 16
-                ? selectedLocation.tagValue.slice(0, 16) + "..."
-                : selectedLocation.tagValue
-              : "Select"}
-          </MenuButton>
-          <MenuList
-            maxHeight="240px"
-            overflowY="auto"
-            minW="0"
-          >
-            <MenuOptionGroup
-              title=""
-              type="radio"
-              value={locationId === "" ? "" : String(locationId)}
-              onChange={(value) => setLocationId(Number(value))}
+          <InputGroup>
+            <Input
+              value={isOpen ? searchQuery : (selectedLocation?.tagValue ?? "")}
+              onChange={handleInputChange}
+              onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
+              placeholder="Select location"
+              cursor={isOpen ? "text" : "pointer"}
+              readOnly={!isOpen}
+              fontFamily="Inter"
+              fontSize="14px"
+              fontWeight="400"
+              color={selectedLocation || isOpen ? "var(--gray-700, #2D3748)" : "gray.400"}
+              borderRadius="4px"
+              border={isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)"}
+              background="var(--white, #FFF)"
+              _focus={{ boxShadow: "none", borderColor: "inherit" }}
+              pr="2.5rem"
+            />
+            <InputRightElement pointerEvents="none" color="gray.500">
+              <ChevronDown size={20} />
+            </InputRightElement>
+          </InputGroup>
+
+          {isOpen && (
+            <Box
+              position="absolute"
+              top="calc(100% + 4px)"
+              left="0"
+              right="0"
+              zIndex="popover"
+              bg="white"
+              border="1px solid"
+              borderColor="gray.200"
+              borderRadius="md"
+              boxShadow="sm"
+              overflow="hidden"
             >
-              {locations.map((location) => (
-                <MenuItemOption
-                  key={location.id}
-                  value={String(location.id)}
-                  ref={String(location.id) === String(locationId) ? selectedItemRef : null}
-                  pl="3"
-                  pr="0"
-                >
-                  <HStack
-                    justifyContent="space-between"
-                    w="100%"
-                  >
-                    <Text flex="1" fontSize="12px" fontWeight="400">{location.tagValue}</Text>
-                    <Button
-                      as="span"
-                      variant="ghost"
-                      onClick={handleDelete(location)}
-                      isLoading={!!deletingMap[location.id]}
+              <Box
+                overflowY="auto"
+                maxH="180px"
+              >
+                {filteredLocations.map((location) => {
+                  const isSelected = String(location.id) === String(locationId);
+                  return (
+                    <HStack
+                      key={location.id}
+                      px={3}
+                      py={2}
+                      justify="space-between"
+                      cursor="pointer"
+                      bg={isSelected ? "blue.50" : "white"}
+                      _hover={{ bg: isSelected ? "blue.50" : "gray.50" }}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleSelect(location.id)}
                     >
-                      <MdDeleteOutline size={20} />
-                    </Button>
-                  </HStack>
-                </MenuItemOption>
-              ))}
+                      <HStack
+                        flex="1"
+                        gap={2}
+                        minW="0"
+                      >
+                        {isSelected && (
+                          <CheckIcon
+                            boxSize={3}
+                            color="blue.500"
+                            flexShrink={0}
+                          />
+                        )}
+                        <Text
+                          fontSize="12px"
+                          fontWeight="400"
+                          color={isSelected ? "blue.600" : "inherit"}
+                          noOfLines={1}
+                        >
+                          {location.tagValue}
+                        </Text>
+                      </HStack>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        flexShrink={0}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(location)(e);
+                        }}
+                        isLoading={!!deletingMap[location.id]}
+                      >
+                        <MdDeleteOutline size={20} />
+                      </Button>
+                    </HStack>
+                  );
+                })}
+                {filteredLocations.length === 0 && (
+                  <Text
+                    px={3}
+                    py={2}
+                    fontSize="12px"
+                    color="gray.400"
+                  >
+                    No locations found
+                  </Text>
+                )}
+              </Box>
               <HStack
                 px={3}
                 py={2}
                 gap={2}
+                borderTop="1px solid"
+                borderColor="gray.100"
               >
                 <Input
                   placeholder="Enter location"
                   value={newValue}
                   onChange={(e) => setNewValue(e.target.value)}
-                  variant="outline"
-                  fontFamily={"Inter"}
-                  fontStyle={"normal"}
-                  lineHeight={"20px"}
+                  onKeyDown={(e) => { if (e.key === "Enter") handleCreate(e); }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  fontFamily="Inter"
+                  fontStyle="normal"
+                  lineHeight="20px"
                   fontSize="12px"
                   fontWeight="400"
                   color="black"
-                  border={"1px solid var(--gray-200, #E2E8F0)"}
+                  border="1px solid var(--gray-200, #E2E8F0)"
                   borderRadius="4px"
-                  w="100%"
                   h="30px"
-                  padding={"10px"}
-                  margin={"0"}
+                  padding="10px"
                   _placeholder={{ color: "#A0AEC0" }}
                 />
                 <Button
@@ -239,16 +293,12 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                   _hover={{ bg: "none" }}
                   _active={{ bg: "none" }}
                 >
-                  {createLocation.isPending ? (
-                    <Spinner size="xs" />
-                  ) : (
-                    <AddIcon />
-                  )}
+                  {createLocation.isPending ? <Spinner size="xs" /> : <AddIcon />}
                 </Button>
               </HStack>
-            </MenuOptionGroup>
-          </MenuList>
-        </Menu>
+            </Box>
+          )}
+        </Box>
       )}
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -1,23 +1,122 @@
+import { useRef, useState } from "react";
+
+import { AddIcon, CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
+  Button,
   FormControl,
   FormErrorMessage,
   FormLabel,
+  HStack,
+  Input,
   InputGroup,
+  InputRightElement,
+  Spinner,
+  Text,
+  useDisclosure,
+  useOutsideClick,
+  useToast,
 } from "@chakra-ui/react";
+import { ChevronDown } from "lucide-react";
+import { MdDeleteOutline } from "react-icons/md";
 
-import CustomSelect from "@/components/common/CustomSelect";
-
+import {
+  useCreateProvider,
+  useDeleteProvider,
+} from "@/contexts/hooks/data-fetching/useProviders";
+import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
-  const options = providers.map((p) => ({
-    value: String(p.id),
-    label: p.name,
-  }));
+  const createProvider = useCreateProvider();
+  const deleteProvider = useDeleteProvider();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [newValue, setNewValue] = useState("");
+  const [deletingMap, setDeletingMap] = useState({});
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const toast = useToast();
+  const containerRef = useRef(null);
+
+  const debouncedSetSearch = useDebounce((val) => setDebouncedSearch(val), 300);
+
+  const handleClose = () => {
+    setSearchQuery("");
+    setDebouncedSearch("");
+    onClose();
+  };
+
+  useOutsideClick({ ref: containerRef, handler: handleClose });
+
   const selectedProvider = providers.find(
     (provider) => String(provider.id) === String(providerId)
   );
+
+  const filteredProviders = providers.filter((p) =>
+    p.name.toLowerCase().includes(debouncedSearch.toLowerCase())
+  );
+
+  const handleInputChange = (e) => {
+    const val = e.target.value;
+    setSearchQuery(val);
+    debouncedSetSearch(val);
+  };
+
+  const handleSelect = (id) => {
+    setProviderId(id);
+    handleClose();
+  };
+
+  const handleCreate = async (e) => {
+    e.stopPropagation();
+    const trimmed = newValue.trim();
+    if (!trimmed) return;
+
+    try {
+      const result = await createProvider.mutateAsync({ name: trimmed });
+      const newProvider = Array.isArray(result) ? result[0] : result;
+      if (newProvider?.id) setProviderId(newProvider.id);
+      setNewValue("");
+      handleClose();
+    } catch (_err) {
+      toast({
+        title: "Error",
+        description: "Failed to create provider",
+        status: "error",
+        position: "bottom-right",
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = (provider) => (e) => {
+    e.stopPropagation();
+    const id = provider.id;
+    setDeletingMap((m) => ({ ...m, [id]: true }));
+
+    deleteProvider.mutate(id, {
+      onSuccess: () => {
+        setProviderId((prev) => (String(id) === String(prev) ? "" : prev));
+      },
+      onSettled: () =>
+        setDeletingMap((m) => {
+          const copy = { ...m };
+          delete copy[id];
+          return copy;
+        }),
+      onError: () => {
+        toast({
+          title: "Error",
+          description: "Failed to delete provider",
+          status: "error",
+          position: "bottom-right",
+          duration: 5000,
+          isClosable: true,
+        });
+      },
+    });
+  };
 
   return (
     <FormControl
@@ -49,12 +148,152 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
           <LockRightElement />
         </InputGroup>
       ) : (
-        <CustomSelect
-          options={options}
-          value={providerId === "" ? "" : String(providerId)}
-          setValue={(val) => setProviderId(Number(val))}
-          styleProps={isInvalid ? { border: "1px solid #FC8181" } : {}}
-        />
+        <Box
+          ref={containerRef}
+          position="relative"
+        >
+          <InputGroup>
+            <Input
+              value={isOpen ? searchQuery : (selectedProvider?.name ?? "")}
+              onChange={handleInputChange}
+              onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
+              placeholder="Select provider"
+              cursor={isOpen ? "text" : "pointer"}
+              readOnly={!isOpen}
+              fontFamily="Inter"
+              fontSize="14px"
+              fontWeight="400"
+              color={selectedProvider || isOpen ? "var(--gray-700, #2D3748)" : "gray.400"}
+              borderRadius="4px"
+              border={isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)"}
+              background="var(--white, #FFF)"
+              _focus={{ boxShadow: "none", borderColor: "inherit" }}
+              pr="2.5rem"
+            />
+            <InputRightElement pointerEvents="none" color="gray.500">
+              <ChevronDown size={20} />
+            </InputRightElement>
+          </InputGroup>
+
+          {isOpen && (
+            <Box
+              position="absolute"
+              top="calc(100% + 4px)"
+              left="0"
+              right="0"
+              zIndex="popover"
+              bg="white"
+              border="1px solid"
+              borderColor="gray.200"
+              borderRadius="md"
+              boxShadow="sm"
+              overflow="hidden"
+            >
+              <Box
+                overflowY="auto"
+                maxH="180px"
+              >
+                {filteredProviders.map((provider) => {
+                  const isSelected = String(provider.id) === String(providerId);
+                  return (
+                    <HStack
+                      key={provider.id}
+                      px={3}
+                      py={2}
+                      justify="space-between"
+                      cursor="pointer"
+                      bg={isSelected ? "blue.50" : "white"}
+                      _hover={{ bg: isSelected ? "blue.50" : "gray.50" }}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={() => handleSelect(provider.id)}
+                    >
+                      <HStack
+                        flex="1"
+                        gap={2}
+                        minW="0"
+                      >
+                        {isSelected && (
+                          <CheckIcon
+                            boxSize={3}
+                            color="blue.500"
+                            flexShrink={0}
+                          />
+                        )}
+                        <Text
+                          fontSize="12px"
+                          fontWeight="400"
+                          color={isSelected ? "blue.600" : "inherit"}
+                          noOfLines={1}
+                        >
+                          {provider.name}
+                        </Text>
+                      </HStack>
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        flexShrink={0}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDelete(provider)(e);
+                        }}
+                        isLoading={!!deletingMap[provider.id]}
+                      >
+                        <MdDeleteOutline size={20} />
+                      </Button>
+                    </HStack>
+                  );
+                })}
+                {filteredProviders.length === 0 && (
+                  <Text
+                    px={3}
+                    py={2}
+                    fontSize="12px"
+                    color="gray.400"
+                  >
+                    No providers found
+                  </Text>
+                )}
+              </Box>
+              <HStack
+                px={3}
+                py={2}
+                gap={2}
+                borderTop="1px solid"
+                borderColor="gray.100"
+              >
+                <Input
+                  placeholder="Enter provider name"
+                  value={newValue}
+                  onChange={(e) => setNewValue(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") handleCreate(e); }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  fontFamily="Inter"
+                  fontStyle="normal"
+                  lineHeight="20px"
+                  fontSize="12px"
+                  fontWeight="400"
+                  color="black"
+                  border="1px solid var(--gray-200, #E2E8F0)"
+                  borderRadius="4px"
+                  h="30px"
+                  padding="10px"
+                  _placeholder={{ color: "#A0AEC0" }}
+                />
+                <Button
+                  size="xs"
+                  onClick={handleCreate}
+                  isDisabled={createProvider.isPending}
+                  variant="ghost"
+                  _hover={{ bg: "none" }}
+                  _active={{ bg: "none" }}
+                >
+                  {createProvider.isPending ? <Spinner size="xs" /> : <AddIcon />}
+                </Button>
+              </HStack>
+            </Box>
+          )}
+        </Box>
       )}
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { AddIcon, CheckIcon } from "@chakra-ui/icons";
+import { CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -11,7 +11,6 @@ import {
   Input,
   InputGroup,
   InputRightElement,
-  Spinner,
   Text,
   useDisclosure,
   useOutsideClick,
@@ -20,18 +19,13 @@ import {
 import { ChevronDown } from "lucide-react";
 import { MdDeleteOutline } from "react-icons/md";
 
-import {
-  useCreateProvider,
-  useDeleteProvider,
-} from "@/contexts/hooks/data-fetching/useProviders";
+import { useDeleteProvider } from "@/contexts/hooks/data-fetching/useProviders";
 import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
-  const createProvider = useCreateProvider();
   const deleteProvider = useDeleteProvider();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [newValue, setNewValue] = useState("");
   const [deletingMap, setDeletingMap] = useState({});
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -67,26 +61,10 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
     handleClose();
   };
 
-  const handleCreate = async (e) => {
-    e.stopPropagation();
-    const trimmed = newValue.trim();
-    if (!trimmed) return;
-
-    try {
-      const result = await createProvider.mutateAsync({ name: trimmed });
-      const newProvider = Array.isArray(result) ? result[0] : result;
-      if (newProvider?.id) setProviderId(newProvider.id);
-      setNewValue("");
-      handleClose();
-    } catch (_err) {
-      toast({
-        title: "Error",
-        description: "Failed to create provider",
-        status: "error",
-        position: "bottom-right",
-        duration: 5000,
-        isClosable: true,
-      });
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter" && filteredProviders.length > 0) {
+      e.preventDefault();
+      handleSelect(filteredProviders[0].id);
     }
   };
 
@@ -157,7 +135,9 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
               value={isOpen ? searchQuery : (selectedProvider?.name ?? "")}
               onChange={handleInputChange}
               onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
+              onKeyDown={handleKeyDown}
               placeholder="Select provider"
+              autoComplete="off"
               cursor={isOpen ? "text" : "pointer"}
               readOnly={!isOpen}
               fontFamily="Inter"
@@ -255,42 +235,6 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
                   </Text>
                 )}
               </Box>
-              <HStack
-                px={3}
-                py={2}
-                gap={2}
-                borderTop="1px solid"
-                borderColor="gray.100"
-              >
-                <Input
-                  placeholder="Enter provider name"
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  fontFamily="Inter"
-                  fontStyle="normal"
-                  lineHeight="20px"
-                  fontSize="12px"
-                  fontWeight="400"
-                  color="black"
-                  border="1px solid var(--gray-200, #E2E8F0)"
-                  borderRadius="4px"
-                  h="30px"
-                  padding="10px"
-                  _placeholder={{ color: "#A0AEC0" }}
-                />
-                <Button
-                  size="xs"
-                  onClick={handleCreate}
-                  isDisabled={createProvider.isPending}
-                  variant="ghost"
-                  _hover={{ bg: "none" }}
-                  _active={{ bg: "none" }}
-                >
-                  {createProvider.isPending ? <Spinner size="xs" /> : <AddIcon />}
-                </Button>
-              </HStack>
             </Box>
           )}
         </Box>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -266,7 +266,7 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
                   placeholder="Enter provider name"
                   value={newValue}
                   onChange={(e) => setNewValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") handleCreate(e); }}
+                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
                   onMouseDown={(e) => e.stopPropagation()}
                   fontFamily="Inter"
                   fontStyle="normal"

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -3,7 +3,6 @@ import { useRef, useState } from "react";
 import { CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
-  Button,
   FormControl,
   FormErrorMessage,
   FormLabel,
@@ -17,16 +16,12 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { ChevronDown } from "lucide-react";
-import { MdDeleteOutline } from "react-icons/md";
 
-import { useDeleteProvider } from "@/contexts/hooks/data-fetching/useProviders";
 import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
-  const deleteProvider = useDeleteProvider();
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [deletingMap, setDeletingMap] = useState({});
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const toast = useToast();
@@ -66,34 +61,6 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
       e.preventDefault();
       handleSelect(filteredProviders[0].id);
     }
-  };
-
-  const handleDelete = (provider) => (e) => {
-    e.stopPropagation();
-    const id = provider.id;
-    setDeletingMap((m) => ({ ...m, [id]: true }));
-
-    deleteProvider.mutate(id, {
-      onSuccess: () => {
-        setProviderId((prev) => (String(id) === String(prev) ? "" : prev));
-      },
-      onSettled: () =>
-        setDeletingMap((m) => {
-          const copy = { ...m };
-          delete copy[id];
-          return copy;
-        }),
-      onError: () => {
-        toast({
-          title: "Error",
-          description: "Failed to delete provider",
-          status: "error",
-          position: "bottom-right",
-          duration: 5000,
-          isClosable: true,
-        });
-      },
-    });
   };
 
   return (
@@ -208,19 +175,6 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
                           {provider.name}
                         </Text>
                       </HStack>
-                      <Button
-                        variant="ghost"
-                        size="xs"
-                        flexShrink={0}
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDelete(provider)(e);
-                        }}
-                        isLoading={!!deletingMap[provider.id]}
-                      >
-                        <MdDeleteOutline size={20} />
-                      </Button>
                     </HStack>
                   );
                 })}


### PR DESCRIPTION
## Description
added debounced search bar into providers/locations options in quota drawer

## Screenshots/Media
<img width="522" height="392" alt="image" src="https://github.com/user-attachments/assets/0ce2f2fc-eb3d-414f-9882-56aa394ff736" />
<img width="512" height="383" alt="image" src="https://github.com/user-attachments/assets/c73a3a13-e9f0-47c2-9286-2c320f0a96c6" />

## Issues
Closes #220 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the Provider and Location pickers in the quota drawer with search-as-you-type and a unified input dropdown. Removes inline create and addresses the search bars requested in #220.

- **New Features**
  - 300ms debounced search for providers and locations with Enter-to-select, click-outside close, selected checkmark, and empty state.
  - Replaced old select/menu with a custom input dropdown; removed inline create; kept delete with spinner/toast and auto-deselect on delete.

- **Bug Fixes**
  - Prevent form submission when pressing Enter in the search input.

<sup>Written for commit 41d0f747fbea358ceb94411bb2a869dba1d7f9dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

