### PR TITLE
230 modal height

### DIFF
--- a/client/src/components/user-settings/TransferMasterRoleModal.jsx
+++ b/client/src/components/user-settings/TransferMasterRoleModal.jsx
@@ -125,7 +125,7 @@ export default function TransferMasterRoleModal({ isOpen, onClose }) {
       <ModalContent
         padding="0.75em"
         minW="700px"
-        h="565px"
+        minH="565px"
         borderRadius="22px"
       >
         <TransferModalHeader step={step} />

--- a/client/src/components/user-settings/transfer-master/StepFinalize.jsx
+++ b/client/src/components/user-settings/transfer-master/StepFinalize.jsx
@@ -85,7 +85,7 @@ export default function StepFinalize({ onClose, onSelect, onFinalize }) {
         justifyContent="flex-end"
         gap="10px"
         mt="auto"
-        pt="28px"
+        pt="180px"
         mb="-7px"
       >
         <Button


### PR DESCRIPTION
## Description
- Make modal stretch for long names

## Screenshots/Media
<img width="814" height="738" alt="image" src="https://github.com/user-attachments/assets/2705dd60-36f2-4552-bd2e-980ad1b63f5c" />

## Issues
Closes #230 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #230 by replacing the Transfer Master Role modal’s fixed height with a min height and adjusting footer padding, so long display names fit without overflow and actions stay aligned.

<sup>Written for commit 77b2fb8bfef9245829966b1c4873b38af8e0b825. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/clchc/pull/231?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

