### PR TITLE
233 appt type in quota table shows raw db values

### DIFF
--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -18,6 +18,7 @@ import {
 import { MdSentimentDissatisfied } from "react-icons/md";
 
 import TextPopup from "@/components/common/TextPopup";
+import { TYPE_OPTIONS } from "@/components/quota-tracking/quota-drawer/tools/constants";
 import ProgressBar from "@/components/quota-tracking/ProgressBar";
 import QuotaDrawer from "@/components/quota-tracking/QuotaDrawer";
 
@@ -234,7 +235,7 @@ const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
                     textColor="white"
                     borderRadius="6px"
                   >
-                    <Text textTransform="capitalize">{row.appointmentType}</Text>
+                    {TYPE_OPTIONS.find((o) => o.value === row.appointmentType)?.label ?? row.appointmentType}
                   </Badge>
                 </Td>
 

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
@@ -32,7 +32,7 @@ export const TypeInput = ({ type, setType, isLocked, isInvalid }) => {
             bg="gray.50"
             color="gray.500"
           >
-            {type}
+            {TYPE_OPTIONS.find((o) => o.value === type)?.label ?? type}
           </Box>
           <LockRightElement />
         </InputGroup>

--- a/client/src/components/quota-tracking/quota-drawer/tools/constants.js
+++ b/client/src/components/quota-tracking/quota-drawer/tools/constants.js
@@ -1,8 +1,8 @@
 export const MAX_INPUT_NUMBER = 99;
 
 export const TYPE_OPTIONS = [
-  { value: "inperson", label: "In-Person" },
-  { value: "telehealth", label: "Tele-Health" },
+  { value: "inperson", label: "In Person" },
+  { value: "telehealth", label: "Telehealth" },
 ];
 
 export const inputStyles = {

--- a/client/src/components/quota-tracking/quota-drawer/tools/constants.js
+++ b/client/src/components/quota-tracking/quota-drawer/tools/constants.js
@@ -1,8 +1,8 @@
 export const MAX_INPUT_NUMBER = 99;
 
 export const TYPE_OPTIONS = [
-  { value: "inperson", label: "In-person" },
-  { value: "telehealth", label: "Tele-health" },
+  { value: "inperson", label: "In-Person" },
+  { value: "telehealth", label: "Tele-Health" },
 ];
 
 export const inputStyles = {

--- a/client/src/components/user-directory/UserEditModal.jsx
+++ b/client/src/components/user-directory/UserEditModal.jsx
@@ -60,7 +60,7 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
     if (user) setSelectedRole(user.role ?? "viewer");
   }, [user]);
 
-  if (!user) return null;
+  if (!user) return null;3
 
   const currentFirebaseUid = user.firebaseUid;
   const username = user.firstName + " " + user.lastName;
@@ -77,6 +77,8 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
       return;
     }
 
+    
+
     try {
       await updateUser({
         uid: currentFirebaseUid,
@@ -89,7 +91,7 @@ export default function UserEditModal({ isOpen, onClose, userId, onUpdated }) {
     } catch (err) {
       console.error("Approval failed: ", err);
     }
-  };
+  };asdf
 
   const onDelete = async () => {
     if (!currentFirebaseUid) {


### PR DESCRIPTION
## Description
fixed appointment type to use more natural look instead of db values directly


## Screenshots/Media
<img width="169" height="132" alt="image" src="https://github.com/user-attachments/assets/303864e2-bbc1-4582-948c-b80cc0f2b548" />


## Issues
Closes #233 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show human-friendly appointment type labels in quota tracking instead of raw DB values. Fixes #233 and makes table badges and the drawer’s locked input consistent.

- **Bug Fixes**
  - Map `appointmentType` to display label via `TYPE_OPTIONS` in the quota table badge.
  - Use the same label in `TypeInput` when locked.
  - Update `TYPE_OPTIONS` labels to "In Person" and "Telehealth".

<sup>Written for commit b837ef4490808f1c012865003e7e305b77c8511a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

