### PR TITLE
235 fix popovers

### DIFF
--- a/client/src/components/common/TextPopup.jsx
+++ b/client/src/components/common/TextPopup.jsx
@@ -1,14 +1,15 @@
+import { useState } from "react";
+
 import { Box, Popover, PopoverArrow, PopoverBody, PopoverContent, PopoverTrigger, Portal, Text } from "@chakra-ui/react";
 
-
-
-
-
 const TextPopup = ({ text = "" }) => {
+  const [isOpen, setIsOpen] = useState(false);
 
   return (
     <Popover
-      trigger="click"
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      closeOnBlur={false}
     >
       <PopoverTrigger>
         <Box
@@ -16,6 +17,7 @@ const TextPopup = ({ text = "" }) => {
           cursor="pointer"
           onClick={(e) => {
             e.stopPropagation();
+            setIsOpen((prev) => !prev);
           }}
         >
           <Text

--- a/client/src/components/common/TextPopup.jsx
+++ b/client/src/components/common/TextPopup.jsx
@@ -1,30 +1,22 @@
-import { useState } from "react";
-
-
-
 import { Box, Popover, PopoverArrow, PopoverBody, PopoverContent, PopoverTrigger, Portal, Text } from "@chakra-ui/react";
 
 
 
 
 
-const TextPopup = ({ text = "", alwaysShowPopup = false, truncateAt }) => {
-  const [isOpen, setIsOpen] = useState(false);
+const TextPopup = ({ text = "" }) => {
 
   return (
     <Popover
-      isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
+      trigger="click"
     >
       <PopoverTrigger>
         <Box
           maxWidth="100px"
           cursor="pointer"
-          onDoubleClick={(e) => {
+          onClick={(e) => {
             e.stopPropagation();
-            setIsOpen(true);
           }}
-          onClick={(e) => e.stopPropagation()}
         >
           <Text
             isTruncated

--- a/client/src/components/quota-tracking/QuotaTable.jsx
+++ b/client/src/components/quota-tracking/QuotaTable.jsx
@@ -249,11 +249,11 @@ const QuotaTable = ({ rows, loading, onRowsUpdate, role }) => {
                 <Td {...tdProps}>
                   {!row.notes ? (
                     <Text {...tdTextProps} color="gray.500">No notes.</Text>
-                  ) : row.notes.length > 200 ? (
+                  ) : row.notes.length > 100 ? (
                     <TextPopup
                       text={row.notes}
                       alwaysShowPopup={true}
-                      truncateAt={200}
+                      truncateAt={100}
                     />
                   ) : (
                     <Text {...tdTextProps} color="gray.500">{row.notes}</Text>


### PR DESCRIPTION
## Description
adjusted popovers to allow for truncate at 100 characters (matching provider directory). allowed single click to open popovers rather than double click for easier user interaction. 

## Screenshots/Media
<img width="758" height="146" alt="image" src="https://github.com/user-attachments/assets/e40b8531-72bb-4edb-92df-773764c8c309" />
<img width="546" height="406" alt="image" src="https://github.com/user-attachments/assets/3d3f025d-73aa-4119-b0d5-98b9102062cf" />


## Issues
Closes #235 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Popovers now toggle on single click; notes truncate at 100 characters to match the provider directory. Closes #235.

<sup>Written for commit bcf0946d5285dfbae472602bacf6056af4d5f6a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

