### PR TITLE
236 fix quota drawer notification banner

### DIFF
--- a/client/src/components/quota-tracking/quota-drawer/NotificationBanner.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/NotificationBanner.jsx
@@ -5,13 +5,18 @@ import { AlertCircle } from "lucide-react";
 import { actionMessage } from "./tools/constants";
 
 export const NotificationBanner = ({ action }) => {
+
+  const colors = action === "delete"
+  ? { bg: "#FFD2D2", primary: "#CE0000" }
+  : { bg: "#D2E8FF", primary: "#0050CE" };
+
   return (
     <Box
-      bg="#FFD2D2"
+      bg={colors.bg}
       borderRadius="8px"
       p={4}
       border="2px solid"
-      borderColor="#CE0000"
+      borderColor={colors.primary}
     >
       <Stack
         direction="row"
@@ -20,11 +25,11 @@ export const NotificationBanner = ({ action }) => {
       >
         <AlertCircle
           size={24}
-          color="#CE0000"
+          color={colors.primary}
         />
         <Text
           fontWeight="semibold"
-          color="#CE0000"
+          color={colors.primary}
           display="flex"
           alignItems="center"
           lineHeight="1"
@@ -35,7 +40,7 @@ export const NotificationBanner = ({ action }) => {
 
       <Text
         fontSize="sm"
-        color="#CE0000"
+        color={colors.primary}
       >
         {actionMessage[action ? action : "create"]}
       </Text>


### PR DESCRIPTION
## Description
changed notification banner file to allow for dynamic coloring based on user action. based colors on provider directory actions using same terminology (primary, bg)


## Screenshots/Media
<img width="445" height="437" alt="image" src="https://github.com/user-attachments/assets/0d54c9f8-70b8-4142-8695-dfc5afe39c63" />


## Issues
Closes #236 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the quota drawer notification banner use dynamic colors based on the user action. Addresses #236 by aligning styles with provider directory tokens and showing red for delete, blue for other actions.

- **Bug Fixes**
  - Uses { bg: #FFD2D2, primary: #CE0000 } for delete; { bg: #D2E8FF, primary: #0050CE } for others.
  - Applies `primary` to border/icon/text and `bg` to the banner; falls back to the create message when action is missing.

<sup>Written for commit a64316dc5ee3ba40efb8416cdf25b8819a3896cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

