### PR TITLE
239 remove shadow on cards

### DIFF
--- a/client/src/components/common/CustomCard.jsx
+++ b/client/src/components/common/CustomCard.jsx
@@ -10,7 +10,6 @@ export const CustomCard = ({ title, body, footer, footerUnderline, footerColor, 
       borderColor="gray.200"
       borderRadius="lg"
       boxShadow="sm"
-      _hover={{ boxShadow: "md" }}
       transition="box-shadow 0.2s ease"
     >
       <CardHeader pb="9px">


### PR DESCRIPTION
## Description
lol no shadow idk how the screenshot can show it tho. removed hover affect

## Screenshots/Media
<img width="616" height="259" alt="image" src="https://github.com/user-attachments/assets/78fe49f2-9e5c-4582-88b4-a03ff67ab21c" />

## Issues
Closes #239 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hover box-shadow from `CustomCard` so cards no longer elevate on hover. Cards keep a small static shadow for a consistent look, aligning with #239.

<sup>Written for commit 1518cbf61c19c399c185503451291f41f5c078a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

