### PR TITLE
240 toasts toasts and toasts some more toasts

### DIFF
--- a/client/src/components/common/ToastAlert.jsx
+++ b/client/src/components/common/ToastAlert.jsx
@@ -1,0 +1,27 @@
+import { Alert, AlertDescription, AlertIcon, AlertTitle, Box, CloseButton } from "@chakra-ui/react";
+
+const ToastAlert = ({ status, borderColor, title, description, onClose }) => (
+  <Alert
+    status={status}
+    borderBottom={`4px solid ${borderColor}`}
+    boxShadow="md"
+    pr={8}
+    position="relative"
+  >
+    <AlertIcon />
+    <Box>
+      <AlertTitle fontSize="14px" fontWeight="700">{title}</AlertTitle>
+      <AlertDescription fontSize="12px">{description}</AlertDescription>
+    </Box>
+    <CloseButton
+      position="absolute"
+      right={2}
+      top="50%"
+      transform="translateY(-50%)"
+      boxSize="18px"
+      onClick={onClose}
+    />
+  </Alert>
+);
+
+export default ToastAlert;

--- a/client/src/components/provider-directory/CategoryDrawer.jsx
+++ b/client/src/components/provider-directory/CategoryDrawer.jsx
@@ -422,9 +422,15 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
 
       newCategories.forEach((cat) => {
         toast({
-          position: "bottom-right",
+          position: "top-right",
           duration: 5000,
           isClosable: true,
+          containerStyle: {
+            width: "401px",
+            maxWidth: "401px",
+            height: "66px",
+            maxHeight: "66px",
+          },
           render: ({ onClose }) => (
             <Alert
               status="success"
@@ -436,11 +442,11 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
               <AlertIcon />
               <Box>
                 <AlertTitle fontSize="14px" fontWeight="700">Category Created</AlertTitle>
-                <AlertDescription fontSize="13px" >
+                <AlertDescription fontSize="12px" >
                   You have created the new category &ldquo;{cat.name}&rdquo;.
                 </AlertDescription>
               </Box>
-              <CloseButton position="absolute" right={2} top={2} size="sm" onClick={onClose} />
+              <CloseButton position="absolute" right={2} top="50%" transform="translateY(-50%)" boxSize="18px" onClick={onClose} />
             </Alert>
           ),
         });
@@ -448,9 +454,15 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
 
       deletedNames.forEach((name) => {
         toast({
-          position: "bottom-right",
+          position: "top-right",
           duration: 5000,
           isClosable: true,
+          containerStyle: {
+            width: "401px",
+            maxWidth: "401px",
+            height: "66px",
+            maxHeight: "66px",
+          },
           render: ({ onClose }) => (
             <Alert
               status="error"
@@ -462,11 +474,11 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
               <AlertIcon />
               <Box gap = {0}>
                 <AlertTitle fontSize="14px" fontWeight="700">Category Deletion</AlertTitle>
-                <AlertDescription fontSize="13px">
+                <AlertDescription fontSize="12px">
                   You have deleted the category &ldquo;{name}&rdquo;.
                 </AlertDescription>
               </Box>
-              <CloseButton position="absolute" right={2} top={2} size="sm" onClick={onClose} />
+              <CloseButton position="absolute" right={2} top="50%" transform="translateY(-50%)" boxSize="18px" onClick={onClose} />
             </Alert>
           ),
         });
@@ -482,7 +494,7 @@ const CategoryDrawer = ({ isOpen, onClose, onSaved }) => {
       }
     } catch (err) {
       const errorMessage =
-        err?.response?.data || err.message || "Failed to save changes";
+        err?.response?.data?.error || err?.response?.data?.message || err.message || "Failed to save changes";
       console.error(
         "Failed to save changes",
         err?.response?.status,

--- a/client/src/components/provider-directory/ProviderDrawer.jsx
+++ b/client/src/components/provider-directory/ProviderDrawer.jsx
@@ -25,6 +25,7 @@ import {
 } from "@chakra-ui/react";
 
 import { useApi } from "@/api.js";
+import ToastAlert from "@/components/common/ToastAlert";
 import TagSelect from "@/components/provider-directory/TagSelect";
 import {
   useCreateProvider,
@@ -542,6 +543,15 @@ const ProviderDrawer = ({
 
       if (activeMode === "create") {
         await createProvider(buildPayload(formValuesAfterTagDeletes));
+        toast({
+          position: "top-right",
+          duration: 5000,
+          isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="success" borderColor="#0C824D" title="Provider Created" description="A new provider has been added to the directory." onClose={onClose} />
+          ),
+        });
       } else if (activeMode === "edit") {
         await updateProvider({
           id: provider.id,
@@ -550,13 +560,13 @@ const ProviderDrawer = ({
       } else if (activeMode === "delete") {
         await deleteProvider(provider.id);
         toast({
-          title: "Provider Deletion",
-          description: "You have deleted a provider from the directory.",
-          status: "error", // This is a successful delete, but the toast should be red according to Hi-Fi.
-          position: "bottom-right",
-          variant: "top-accent",
+          position: "top-right",
           duration: 5000,
           isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="error" borderColor="#90080F" title="Provider Deletion" description="You have deleted a provider from the directory." onClose={onClose} />
+          ),
         });
       }
 
@@ -565,12 +575,13 @@ const ProviderDrawer = ({
     } catch (err) {
       console.error(`Failed to ${activeMode} provider`, err);
       toast({
-        title: "Error",
-        description: errorToString(err),
-        status: "error",
-        position: "bottom-right",
+        position: "top-right",
         duration: 5000,
         isClosable: true,
+        containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+        render: ({ onClose }) => (
+          <ToastAlert status="error" borderColor="#90080F" title="Error" description={errorToString(err)} onClose={onClose} />
+        ),
       });
     }
   };

--- a/client/src/components/provider-directory/TagSelect.jsx
+++ b/client/src/components/provider-directory/TagSelect.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import ToastAlert from "@/components/common/ToastAlert";
 
 import { AddIcon } from "@chakra-ui/icons";
 import {
@@ -126,12 +127,13 @@ const TagSelect = ({
 
       // feedback for successfully (or not) creating tags
       toast({
-        title: "Success",
-        description: "New tag created!",
-        status: "success",
-        position: "bottom-right",
+        position: "top-right",
         duration: 5000,
         isClosable: true,
+        containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+        render: ({ onClose }) => (
+          <ToastAlert status="success" borderColor="#0C824D" title="Tag Created" description="New tag created!" onClose={onClose} />
+        ),
       });
     } catch (err) {
       console.error("Failed to create tag", err);
@@ -142,12 +144,13 @@ const TagSelect = ({
       setNewTagValue(trimmedTag);
 
       toast({
-        title: "Error",
-        description: errorToString(err),
-        status: "error",
-        position: "bottom-right",
+        position: "top-right",
         duration: 5000,
         isClosable: true,
+        containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+        render: ({ onClose }) => (
+          <ToastAlert status="error" borderColor="#90080F" title="Error" description={errorToString(err)} onClose={onClose} />
+        ),
       });
     } finally {
       setCreating(false);
@@ -195,24 +198,26 @@ const TagSelect = ({
 
         if (typeof refetchTags === "function") await refetchTags();
         toast({
-          title: "Success",
-          description: "Tag successfully deleted!",
-          status: "success",
-          position: "bottom-right",
+          position: "top-right",
           duration: 5000,
           isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="success" borderColor="#0C824D" title="Tag Deleted" description="Tag successfully deleted!" onClose={onClose} />
+          ),
         });
       } catch (err) {
         console.error("Failed to delete tag", err);
         queryClient.setQueryData(["tags"], prevTags);
         onTagsChange(prevSelectedIds);
         toast({
-          title: "Error",
-          description: errorToString(err),
-          status: "error",
-          position: "bottom-right",
+          position: "top-right",
           duration: 5000,
           isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="error" borderColor="#90080F" title="Error" description={errorToString(err)} onClose={onClose} />
+          ),
         });
       } finally {
         setDeletingMap((m) => {

--- a/client/src/components/quota-tracking/ProgressBar.jsx
+++ b/client/src/components/quota-tracking/ProgressBar.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import { Button, Flex, Icon, Progress, Text, useToast } from "@chakra-ui/react";
+import ToastAlert from "@/components/common/ToastAlert";
 
 import { useDebounce } from "@/hooks/useDebounce";
 import { useUpdateQuota } from "@/contexts/hooks/data-fetching/useQuotas";
@@ -41,13 +42,13 @@ export default function ProgressBar({ quota }) {
     const baseline = confirmedRef.current ?? quotaRef.current?.progress ?? 0;
     setCurrentProgress(baseline);
     toast({
-      title: "Update failed",
-      description:
-        "Your changes couldn't be saved. Progress has been restored.",
-      status: "error",
+      position: "top-right",
       duration: 4000,
       isClosable: true,
-      position: "bottom-right",
+      containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+      render: ({ onClose }) => (
+        <ToastAlert status="error" borderColor="#90080F" title="Update Failed" description="Your changes couldn't be saved. Progress has been restored." onClose={onClose} />
+      ),
     });
   };
 

--- a/client/src/components/quota-tracking/QuotaDrawer.jsx
+++ b/client/src/components/quota-tracking/QuotaDrawer.jsx
@@ -11,8 +11,10 @@ import {
   Stack,
   Text,
   useDisclosure,
+  useToast,
   Skeleton
 } from "@chakra-ui/react";
+import ToastAlert from "@/components/common/ToastAlert";
 
 import {
   useCreateQuota,
@@ -87,7 +89,8 @@ export default function QuotaDrawer({
   const [errors, setErrors] = useState({});
 
   const { mutate: createLog } = useCreateLog();
-  
+  const toast = useToast();
+
   const apptCalcFactor = userInfo?.dbUser?.apptCalcFactor ?? null;
 
   const currentDrawerTitle = !quotaID
@@ -235,10 +238,28 @@ export default function QuotaDrawer({
       //create
       if (!quotaID) {
         await createQuota(formData);
+        toast({
+          position: "top-right",
+          duration: 5000,
+          isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="success" borderColor="#0C824D" title="Quota Created" description="A new quota has been added." onClose={onClose} />
+          ),
+        });
       }
       //delete
       else if (effectiveAction === "delete") {
         await deleteQuota({ id: quotaID });
+        toast({
+          position: "top-right",
+          duration: 5000,
+          isClosable: true,
+          containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+          render: ({ onClose }) => (
+            <ToastAlert status="error" borderColor="#90080F" title="Quota Deleted" description="The quota has been deleted." onClose={onClose} />
+          ),
+        });
         handleClose();
       }
       //update

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -21,6 +21,7 @@ import { MdDeleteOutline } from "react-icons/md";
 
 import { useDeleteLocation } from "@/contexts/hooks/data-fetching/useLocations";
 import { useDebounce } from "@/hooks/useDebounce";
+import ToastAlert from "@/components/common/ToastAlert";
 import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
@@ -92,12 +93,13 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
           }),
         onError: () => {
           toast({
-            title: "Error",
-            description: "Failed to delete location",
-            status: "error",
-            position: "bottom-right",
+            position: "top-right",
             duration: 5000,
             isClosable: true,
+            containerStyle: { width: "401px", maxWidth: "401px", height: "66px", maxHeight: "66px" },
+            render: ({ onClose }) => (
+              <ToastAlert status="error" borderColor="#90080F" title="Error" description="Failed to delete location." onClose={onClose} />
+            ),
           });
         },
       }


### PR DESCRIPTION
## Description
extracted the toast component to adjust for hi-fi and used in every location toasts should exist. also made it top right instead of bottom left

## Screenshots/Media
<img width="444" height="107" alt="image" src="https://github.com/user-attachments/assets/976beb21-8e39-4b89-ae9f-984532ab9a83" />


## Issues
Closes #240 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a shared `ToastAlert` component and replaces ad‑hoc toasts across the app to match the hi‑fi design. All toasts now appear top‑right with consistent styling; aligns with and closes #240.

- **Refactors**
  - Added `ToastAlert` (Chakra `Alert` wrapper) with accent border, compact copy, and centered close button.
  - Replaced toasts in CategoryDrawer, ProviderDrawer, TagSelect, ProgressBar, QuotaDrawer, and LocationDropdown.
  - Standardized placement to top‑right with fixed container size (401×66) and shadow.
  - Aligned colors: success green `#0C824D`; error red `#90080F` (deletes use red per spec).
  - Improved errors: surfaces backend `error`/`message` in CategoryDrawer; ProgressBar restores value and shows failure toast.

<sup>Written for commit 76651b034ffb613fa2de6cf8a35fc99318275bfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

