### PR TITLE
234 revive crud in location dropdown

### DIFF
--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { AddIcon, CheckIcon } from "@chakra-ui/icons";
+import { AddIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -11,15 +11,12 @@ import {
   Icon,
   Input,
   InputGroup,
-  InputRightElement,
-  Spinner,
   Menu,
   MenuButton,
   MenuItem,
   MenuItemOption,
   MenuList,
   MenuOptionGroup,
-  Skeleton,
   Text,
   useToast,
 } from "@chakra-ui/react";
@@ -27,26 +24,20 @@ import {
 import {
   useCreateLocation,
   useDeleteLocation,
-  useLocations,
 } from "@/contexts/hooks/data-fetching/useLocations";
 import { ChevronDown } from "lucide-react";
 import { MdDeleteOutline } from "react-icons/md";
 
-import {
-  useCreateLocation,
-  useDeleteLocation,
-} from "@/contexts/hooks/data-fetching/useLocations";
-import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
   const createLocation = useCreateLocation();
   const deleteLocation = useDeleteLocation();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [menuOpen, setMenuOpen] = useState(false);
   const [newValue, setNewValue] = useState("");
-  const [deletingMap, setDeletingMap] = useState({});
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [pendingDeleteIds, setPendingDeleteIds] = useState([]);
+  const [isDeleteConfirmArmed, setIsDeleteConfirmArmed] = useState(false);
+  const [isAddingLocation, setIsAddingLocation] = useState(false);
   const toast = useToast();
   const selectedItemRef = useRef(null);
 
@@ -62,27 +53,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       }, 0);
     }
   }, [menuOpen]);
-
-  useEffect(() => {
-    if (typeof onDifferentChange === "function") {
-      onDifferentChange(isDifferent);
-    }
-  }, [isDifferent, onDifferentChange]);
-
-  if (loadingLocations) {
-    return (
-      <FormControl w="50%">
-        <Skeleton
-          height="16px"
-          mb={2}
-        />
-        <Skeleton
-          height="40px"
-          borderRadius="6px"
-        />
-      </FormControl>
-    );
-  }
 
   const selectedLocation = locations.find(
     (location) => String(location.id) === String(locationId)
@@ -101,12 +71,8 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
     });
   };
 
-  const handleCreate = async () => {
-    const trimmed = newValue.trim();
-    if (!trimmed) return;
-
   const handleCreate = async (e) => {
-    e.stopPropagation();
+    e?.stopPropagation();
     const trimmed = newValue.trim();
     if (!trimmed) return;
 
@@ -115,7 +81,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       const newLocation = Array.isArray(result) ? result[0] : result;
       if (newLocation?.id) setLocationId(newLocation.id);
       setNewValue("");
-      handleClose();
+      handleCancel();
     } catch (_err) {
       toast({
         title: "Error",
@@ -135,7 +101,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       setIsDeleteConfirmArmed(false);
       return;
     }
-    e.stopPropagation();
     setPendingDeleteIds((prev) => [...prev, location.id]);
     setIsDeleteConfirmArmed(false);
     setIsAddingLocation(false);
@@ -147,7 +112,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       setIsDeleteConfirmArmed(true);
       return;
     }
-
     handleConfirm();
   };
 
@@ -170,7 +134,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
   const handleConfirm = async () => {
     try {
       for (const id of pendingDeleteIds) {
-        await deleteLocation({ id });
+        await deleteLocation.mutateAsync({ id });
       }
 
       if (
@@ -194,9 +158,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       });
     }
   };
-
-  const menuMaxHeight =
-    pendingDeleteIds.length > 0 && isDeleteConfirmArmed ? "300px" : "240px";
 
   return (
     <FormControl
@@ -240,30 +201,38 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
           closeOnSelect={false}
           matchWidth
         >
-          <InputGroup>
-            <Input
-              value={isOpen ? searchQuery : (selectedLocation?.tagValue ?? "")}
-              onChange={handleInputChange}
-              onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
-              placeholder="Select location"
-              cursor={isOpen ? "text" : "pointer"}
-              readOnly={!isOpen}
-              fontFamily="Inter"
-              fontSize="14px"
-              fontWeight="400"
-              color={selectedLocation || isOpen ? "var(--gray-700, #2D3748)" : "gray.400"}
-              borderRadius="4px"
-              border={isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)"}
-              background="var(--white, #FFF)"
-              _focus={{ boxShadow: "none", borderColor: "inherit" }}
-              pr="2.5rem"
-            />
-            <InputRightElement pointerEvents="none" color="gray.500">
+          <MenuButton
+            as={Box}
+            onClick={handleMenuOpen}
+            w="100%"
+            border={isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)"}
+            borderRadius="4px"
+            bg="white"
+            px={3}
+            py={2}
+            fontSize="14px"
+            color={selectedLocation ? "var(--gray-700, #2D3748)" : "gray.400"}
+            cursor="pointer"
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            <HStack
+              justifyContent="space-between"
+              w="100%"
+            >
+              <Text>{selectedLocation?.tagValue ?? "Select location"}</Text>
               <ChevronDown size={20} />
-            </InputRightElement>
-          </InputGroup>
+            </HStack>
+          </MenuButton>
 
-          {isOpen && (
+          <MenuList
+            p={2}
+            minW="0"
+            w="100%"
+            boxShadow="md"
+            borderRadius="6px"
+          >
             <Box
               maxH="180px"
               overflowY="auto"
@@ -279,7 +248,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                 value={locationId === "" ? "" : String(locationId)}
                 onChange={(value) => setLocationId(Number(value))}
               >
-                {/* Existing locations, minus staged deletes */}
                 {locations.map((location) => (
                   <MenuItemOption
                     key={location.id}
@@ -350,22 +318,21 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                         if (e.key === "Enter") {
                           e.preventDefault();
                           e.stopPropagation();
-                          void handleCreate();
+                          void handleCreate(e);
                         }
                       }}
-                      variant="outline"
-                      fontFamily={"Inter"}
-                      fontStyle={"normal"}
-                      lineHeight={"20px"}
+                      fontFamily="Inter"
+                      fontStyle="normal"
+                      lineHeight="20px"
                       fontSize="12px"
                       fontWeight="400"
                       color="black"
-                      border={"1px solid var(--gray-200, #E2E8F0)"}
+                      border="1px solid var(--gray-200, #E2E8F0)"
                       borderRadius="4px"
                       w="100%"
                       h="30px"
-                      padding={"10px"}
-                      margin={"0"}
+                      padding="10px"
+                      margin="0"
                       _placeholder={{ color: "#A0AEC0" }}
                       isDisabled={isDeletingLocations}
                       autoFocus
@@ -396,43 +363,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                     </HStack>
                   </MenuItem>
                 )}
-              </Box>
-              <HStack
-                px={3}
-                py={2}
-                gap={2}
-                borderTop="1px solid"
-                borderColor="gray.100"
-              >
-                <Input
-                  placeholder="Enter location"
-                  value={newValue}
-                  onChange={(e) => setNewValue(e.target.value)}
-                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  fontFamily="Inter"
-                  fontStyle="normal"
-                  lineHeight="20px"
-                  fontSize="12px"
-                  fontWeight="400"
-                  color="black"
-                  border="1px solid var(--gray-200, #E2E8F0)"
-                  borderRadius="4px"
-                  h="30px"
-                  padding="10px"
-                  _placeholder={{ color: "#A0AEC0" }}
-                />
-                <Button
-                  size="xs"
-                  onClick={handleCreate}
-                  isDisabled={createLocation.isPending}
-                  variant="ghost"
-                  _hover={{ bg: "none" }}
-                  _active={{ bg: "none" }}
-                >
-                  {createLocation.isPending ? <Spinner size="xs" /> : <AddIcon />}
-                </Button>
-              </HStack>
+              </MenuOptionGroup>
             </Box>
 
             <HStack

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 
-import { CheckIcon } from "@chakra-ui/icons";
+import { AddIcon, CheckIcon } from "@chakra-ui/icons";
 import {
   Box,
   Button,
@@ -11,6 +11,7 @@ import {
   Input,
   InputGroup,
   InputRightElement,
+  Spinner,
   Text,
   useDisclosure,
   useOutsideClick,
@@ -19,13 +20,18 @@ import {
 import { ChevronDown } from "lucide-react";
 import { MdDeleteOutline } from "react-icons/md";
 
-import { useDeleteLocation } from "@/contexts/hooks/data-fetching/useLocations";
+import {
+  useCreateLocation,
+  useDeleteLocation,
+} from "@/contexts/hooks/data-fetching/useLocations";
 import { useDebounce } from "@/hooks/useDebounce";
 import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
+  const createLocation = useCreateLocation();
   const deleteLocation = useDeleteLocation();
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [newValue, setNewValue] = useState("");
   const [deletingMap, setDeletingMap] = useState({});
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
@@ -61,15 +67,26 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
     handleClose();
   };
 
-  const handleKeyDown = (e) => {
-    if (e.key === "Enter") {
-      const immediateFilteredLocations = locations.filter((l) =>
-        l.tagValue.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      if (immediateFilteredLocations.length > 0) {
-        e.preventDefault();
-        handleSelect(immediateFilteredLocations[0].id);
-      }
+  const handleCreate = async (e) => {
+    e.stopPropagation();
+    const trimmed = newValue.trim();
+    if (!trimmed) return;
+
+    try {
+      const result = await createLocation.mutateAsync({ tagValue: trimmed });
+      const newLocation = Array.isArray(result) ? result[0] : result;
+      if (newLocation?.id) setLocationId(newLocation.id);
+      setNewValue("");
+      handleClose();
+    } catch (_err) {
+      toast({
+        title: "Error",
+        description: "Failed to create location",
+        status: "error",
+        position: "bottom-right",
+        duration: 5000,
+        isClosable: true,
+      });
     }
   };
 
@@ -145,10 +162,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
               value={isOpen ? searchQuery : (selectedLocation?.tagValue ?? "")}
               onChange={handleInputChange}
               onFocus={() => { setSearchQuery(""); setDebouncedSearch(""); onOpen(); }}
-              onClick={() => { if (!isOpen) { setSearchQuery(""); setDebouncedSearch(""); onOpen(); } }}
-              onKeyDown={handleKeyDown}
               placeholder="Select location"
-              autoComplete="off"
               cursor={isOpen ? "text" : "pointer"}
               readOnly={!isOpen}
               fontFamily="Inter"
@@ -246,6 +260,42 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                   </Text>
                 )}
               </Box>
+              <HStack
+                px={3}
+                py={2}
+                gap={2}
+                borderTop="1px solid"
+                borderColor="gray.100"
+              >
+                <Input
+                  placeholder="Enter location"
+                  value={newValue}
+                  onChange={(e) => setNewValue(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleCreate(e); } }}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  fontFamily="Inter"
+                  fontStyle="normal"
+                  lineHeight="20px"
+                  fontSize="12px"
+                  fontWeight="400"
+                  color="black"
+                  border="1px solid var(--gray-200, #E2E8F0)"
+                  borderRadius="4px"
+                  h="30px"
+                  padding="10px"
+                  _placeholder={{ color: "#A0AEC0" }}
+                />
+                <Button
+                  size="xs"
+                  onClick={handleCreate}
+                  isDisabled={createLocation.isPending}
+                  variant="ghost"
+                  _hover={{ bg: "none" }}
+                  _active={{ bg: "none" }}
+                >
+                  {createLocation.isPending ? <Spinner size="xs" /> : <AddIcon />}
+                </Button>
+              </HStack>
             </Box>
           )}
         </Box>


### PR DESCRIPTION
## Description
yeah

## Screenshots/Media
<img width="266" height="390" alt="Screenshot 2026-05-04 113627" src="https://github.com/user-attachments/assets/b54a957b-4d36-487b-a640-6f1cd4f4319d" />
<img width="417" height="484" alt="Screenshot 2026-05-04 113633" src="https://github.com/user-attachments/assets/5e39bd86-561e-40fc-8db1-2422e0b8553c" />

## Issues
Closes #234 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores create/delete in the location dropdown for the quota drawer with an inline input to add locations, auto-select on success, and clear error toasts. Addresses Linear #234.

- **New Features**
  - Simplified dropdown button with chevron and “Select location”; closes after selection.
  - Inline “Enter location” input with Enter-key support; on create, auto-selects and closes; errors show via toast.

- **Refactors**
  - Component now receives `locations` via props; removed `useLocations` and loading skeleton.
  - Switched to `mutateAsync` on `useCreateLocation`/`useDeleteLocation`; dropped duplicate-name precheck and cleaned up event handling.

<sup>Written for commit dff58634c850a100639c7c706356b12981f297b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

