### PR TITLE
Fixed awkward space between header and navbar

### DIFF
--- a/client/src/components/layout/layout.jsx
+++ b/client/src/components/layout/layout.jsx
@@ -12,7 +12,9 @@ const Layout = () => {
             <Box
                 display="inline-flex"
                 width="100%"
-                padding="9px 40px"
+                px="40px"
+                pt="9px"
+                pb="0"
                 alignItems="center"
                 justifyContent="space-between"
             >

--- a/client/src/components/provider-directory/ProviderDirectoryPage.jsx
+++ b/client/src/components/provider-directory/ProviderDirectoryPage.jsx
@@ -98,7 +98,7 @@ export const ProviderDirectoryPage = () => {
   };
 
   return (
-    <Box p={6}>
+    <Box px={6} pb={6}>
       <Flex flexDirection="column" mb={5} gap={6}>
         {/* TOP ROW: PageHeader + Manage Button (Manage only for ccm/master) */}
         <Flex justify="space-between" align="center">

--- a/client/src/components/quota-tracking/QuotaTrackingPage.jsx
+++ b/client/src/components/quota-tracking/QuotaTrackingPage.jsx
@@ -145,7 +145,7 @@ export const QuotaTracking = () => {
   };
 
   return (
-    <Box p={6}>
+    <Box px={6} pb={6}>
       <Flex align="center" justify="space-between" mb={6}>
         <PageHeader
           title="Quota Tracking"

--- a/client/src/components/user-directory/UserDirectoryPage.jsx
+++ b/client/src/components/user-directory/UserDirectoryPage.jsx
@@ -80,7 +80,7 @@ export const UserDirectory = () => {
   }, [users, searchQuery, selectedRole]);
 
   return (
-    <Box p={6}>
+    <Box px={6} pb={6}>
       <Flex
         align="center"
         justify="space-between"

--- a/client/src/components/version-log/VersionLogPage.jsx
+++ b/client/src/components/version-log/VersionLogPage.jsx
@@ -62,7 +62,7 @@ export const VersionLogPage = () => {
   };
 
   return (
-    <Box p={6}>
+    <Box px={6} pb={6}>
       <Flex align="center" justify="space-between" mb={6} h="45px">
         <PageHeader
           title="Audit Log"


### PR DESCRIPTION
## Description
- removed top padding from every page
- less padding on navbar

## Screenshots/Media
<img width="1710" height="160" alt="Screenshot 2026-05-06 at 1 11 26 AM" src="https://github.com/user-attachments/assets/10ba9a31-c005-445b-9111-28a7b06b01a5" />

## Issues
Closes #237 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates the awkward space between the header and navbar by setting the navbar bottom padding to 0 and removing top padding from page containers. Applies to Provider Directory, User Directory, Quota Tracking, and Audit Log pages; closes #237.

<sup>Written for commit 3a85b11b3d03729b2f79c36cb335d9d9548a0e23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

