### PR TITLE
249 removed lock on quota drawer

### DIFF
--- a/client/src/components/common/CalendarCard.jsx
+++ b/client/src/components/common/CalendarCard.jsx
@@ -16,7 +16,7 @@ import {
 
 const DAYS_OF_WEEK = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
-const CalendarCard = ({ value, onChange, fullWidth = false }) => {
+const CalendarCard = ({ value, onChange, fullWidth = false, isReadOnly = false }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [viewMonth, setViewMonth] = useState(() => {
     const d = value ? new Date(value + "T00:00:00") : new Date();
@@ -29,6 +29,7 @@ const CalendarCard = ({ value, onChange, fullWidth = false }) => {
   }, [value]);
 
   const handleOpen = () => {
+    if (isReadOnly) return;
     const d = value ? new Date(value + "T00:00:00") : new Date();
     setViewMonth(new Date(d.getFullYear(), d.getMonth(), 1));
     setIsOpen(true);
@@ -78,7 +79,7 @@ const CalendarCard = ({ value, onChange, fullWidth = false }) => {
       <PopoverTrigger>
         <Button
           variant="outline"
-          rightIcon={<ChevronDownIcon />}
+          rightIcon={isReadOnly ? undefined : <ChevronDownIcon />}
           onClick={handleOpen}
           h="45px"
           w={fullWidth ? "100%" : "110px"}

--- a/client/src/components/common/CustomSelect.jsx
+++ b/client/src/components/common/CustomSelect.jsx
@@ -26,6 +26,7 @@ export default function CustomSelect({
   value,
   setValue,
   isSearchable = false,
+  isReadOnly = false,
   placeholder = "Select option",
   styleProps = {},
 }) {
@@ -68,8 +69,8 @@ export default function CustomSelect({
           <Input
             value={isOpen ? searchQuery : (selectedLabel ?? "")}
             onChange={(e) => { setSearchQuery(e.target.value); debouncedSetSearch(e.target.value); }}
-            onFocus={() => { setSearchQuery(""); onOpen(); }}
-            onClick={() => { if (!isOpen) { setSearchQuery(""); onOpen(); } }}
+            onFocus={() => { if (isReadOnly) return; setSearchQuery(""); onOpen(); }}
+            onClick={() => { if (isReadOnly || isOpen) return; setSearchQuery(""); onOpen(); }}
             placeholder={placeholder}
             autoComplete="off"
             cursor={isOpen ? "text" : "pointer"}
@@ -85,12 +86,14 @@ export default function CustomSelect({
             pr="2.5rem"
             {...styleProps}
           />
-          <InputRightElement
-            pointerEvents="none"
-            color="gray.500"
-          >
-            <ChevronDown size={20} />
-          </InputRightElement>
+          {!isReadOnly && (
+            <InputRightElement
+              pointerEvents="none"
+              color="gray.500"
+            >
+              <ChevronDown size={20} />
+            </InputRightElement>
+          )}
         </InputGroup>
 
         {isOpen && (
@@ -167,12 +170,13 @@ export default function CustomSelect({
   }
 
   return (
+    <Box pointerEvents={isReadOnly ? "none" : undefined}>
     <Menu matchWidth>
       <MenuButton
         as={Button}
         variant="outline"
         w="100%"
-        rightIcon={<ChevronDown size={20} />}
+        rightIcon={isReadOnly ? undefined : <ChevronDown size={20} />}
         justifyContent="flex-start"
         textAlign="left"
         color={selectedLabel ? "var(--gray-700, #2D3748)" : "gray.400"}
@@ -233,5 +237,6 @@ export default function CustomSelect({
         </Box>
       </MenuList>
     </Menu>
+    </Box>
   );
 }

--- a/client/src/components/quota-tracking/QuotaDrawer.jsx
+++ b/client/src/components/quota-tracking/QuotaDrawer.jsx
@@ -381,7 +381,7 @@ export default function QuotaDrawer({
           </Stack>
         </DrawerBody>
         ) : (
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", flex: 1, overflow: "hidden" }}>
             <DrawerBody
               padding="30px 24px 30px 24px"
               >

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/DailyNoteInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/DailyNoteInput.jsx
@@ -1,38 +1,23 @@
-import { Box, FormControl, FormLabel, Textarea } from "@chakra-ui/react";
+import { FormControl, FormLabel, Textarea } from "@chakra-ui/react";
 
 import { inputStyles } from "../tools/constants";
 
 export const DailyNoteInput = ({ note, setNote, isLocked }) => {
   return (
-    <FormControl isDisabled={isLocked}>
+    <FormControl>
       <FormLabel
         fontSize="14px"
         color="#113D64"
       >Daily Notes</FormLabel>
-      {isLocked ? (
-        <Box
-          w="100%"
-          border="1px"
-          borderColor="gray.300"
-          borderRadius="6px"
-          px={3}
-          py={2}
-          fontSize="14px"
-          bg="gray.50"
-          color="gray.500"
-        >
-          {note ?? ""}
-        </Box>
-      ) : (
-        <Textarea
-          placeholder="Start typing..."
-          size="md"
-          fontSize="14px"
-          {...inputStyles}
-          value={note ?? ""}
-          onChange={(e) => setNote(e.target.value)}
-        />
-      )}
+      <Textarea
+        placeholder="Start typing..."
+        size="md"
+        fontSize="14px"
+        {...inputStyles}
+        isReadOnly={isLocked}
+        value={note ?? ""}
+        onChange={(e) => setNote(e.target.value)}
+      />
     </FormControl>
   );
 };

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/DateInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/DateInput.jsx
@@ -1,52 +1,28 @@
 import {
-  Box,
   FormControl,
   FormErrorMessage,
   FormLabel,
-  InputGroup,
 } from "@chakra-ui/react";
 
 import CalendarCard from "../../../common/CalendarCard";
-import { LockRightElement } from "../tools/shared";
-import { formatDateForDisplay } from "../tools/utils";
 
 export const DateInput = ({ date, setDate, isLocked, isInvalid }) => {
   return (
     <FormControl
       isRequired
       w="45%"
-      isDisabled={isLocked}
       isInvalid={isInvalid}
     >
       <FormLabel
         fontSize="14px"
         color="#113D64"
       >Date</FormLabel>
-      {isLocked ? (
-        <InputGroup>
-          <Box
-            w="100%"
-            border="1px"
-            borderColor="gray.300"
-            borderRadius="6px"
-            px={3}
-            py={2}
-            fontSize="14px"
-            pr="2.25rem"
-            bg="gray.50"
-            color="gray.500"
-          >
-            {formatDateForDisplay(date)}
-          </Box>
-          <LockRightElement />
-        </InputGroup>
-      ) : (
-        <CalendarCard
-          value={date ?? ""}
-          onChange={setDate}
-          fullWidth
-        />
-      )}
+      <CalendarCard
+        value={date ?? ""}
+        onChange={setDate}
+        fullWidth
+        isReadOnly={isLocked}
+      />
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>
   );

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/LocationDropdown.jsx
@@ -10,7 +10,6 @@ import {
   HStack,
   Icon,
   Input,
-  InputGroup,
   Menu,
   MenuButton,
   MenuItem,
@@ -27,8 +26,6 @@ import {
 } from "@/contexts/hooks/data-fetching/useLocations";
 import { ChevronDown } from "lucide-react";
 import { MdDeleteOutline } from "react-icons/md";
-
-import { LockRightElement } from "../tools/shared";
 
 export function LocationDropdown({ locations = [], locationId, setLocationId, isLocked, isInvalid }) {
   const createLocation = useCreateLocation();
@@ -59,6 +56,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
   );
 
   const handleMenuOpen = () => {
+    if (isLocked) return;
     setMenuOpen((prev) => {
       if (prev && isDifferent) return prev;
       if (!prev) {
@@ -163,7 +161,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
     <FormControl
       isRequired
       w="50%"
-      isDisabled={isLocked}
       isInvalid={isInvalid}
     >
       <FormLabel
@@ -172,25 +169,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
       >
         Location
       </FormLabel>
-      {isLocked ? (
-        <InputGroup>
-          <Box
-            w="100%"
-            border="1px"
-            borderColor="gray.300"
-            borderRadius="6px"
-            px={3}
-            py={2}
-            fontSize="14px"
-            pr="2.25rem"
-            bg="gray.50"
-            color="gray.500"
-          >
-            {selectedLocation?.tagValue ?? ""}
-          </Box>
-          <LockRightElement />
-        </InputGroup>
-      ) : (
         <Menu
           isOpen={menuOpen}
           onClose={() => {
@@ -222,7 +200,7 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
               w="100%"
             >
               <Text>{selectedLocation?.tagValue ?? "Select location"}</Text>
-              <ChevronDown size={20} />
+              {!isLocked && <ChevronDown size={20} />}
             </HStack>
           </MenuButton>
 
@@ -341,17 +319,17 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
                 ) : (
                   <MenuItem
                     onClick={() => {
-                      if (isLocked || isDeletingLocations) return;
+                      if (isDeletingLocations) return;
                       setIsAddingLocation(true);
                     }}
-                    isDisabled={isLocked || isDeletingLocations}
+                    isDisabled={isDeletingLocations}
                     bg="white"
                     p="10px 14px 10px 32px"
                     fontSize="12px"
                     fontWeight="400"
                     borderRadius="4px"
                     my="6px"
-                    opacity={isLocked || isDeletingLocations ? 0.4 : 1}
+                    opacity={isDeletingLocations ? 0.4 : 1}
                   >
                     <HStack
                       justifyContent="space-between"
@@ -429,7 +407,6 @@ export function LocationDropdown({ locations = [], locationId, setLocationId, is
             </HStack>
           </MenuList>
         </Menu>
-      )}
 
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/ProviderDropdown.jsx
@@ -1,23 +1,15 @@
 import {
-  Box,
   FormControl,
   FormErrorMessage,
   FormLabel,
-  InputGroup,
 } from "@chakra-ui/react";
 
 import CustomSelect from "@/components/common/CustomSelect";
-import { LockRightElement } from "../tools/shared";
 
 export function ProviderDropdown({ providers = [], providerId, setProviderId, isLocked, isInvalid }) {
-  const selectedProvider = providers.find(
-    (provider) => String(provider.id) === String(providerId)
-  );
-
   const options = providers.map((p) => ({ value: String(p.id), label: p.name }));
 
   const fixedInputProps = {
-    bg: isLocked ? "gray.50" : "white",
     color: "gray.700",
     display: "flex",
     w: "100%",
@@ -27,7 +19,7 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
     gap: "10px",
     borderRadius: "2px",
     border: isInvalid ? "1px solid #FC8181" : "1px solid var(--gray-200, #E2E8F0)",
-    background: isLocked ? "var(--gray-50, #F7FAFC)" : "var(--white, #FFF)",
+    background: "var(--white, #FFF)",
     fontFamily: "Lato",
     fontStyle: "normal",
     fontSize: "14px",
@@ -38,7 +30,6 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
   return (
     <FormControl
       isRequired
-      isDisabled={isLocked}
       isInvalid={isInvalid}
     >
       <FormLabel
@@ -47,26 +38,15 @@ export function ProviderDropdown({ providers = [], providerId, setProviderId, is
       >
         Provider
       </FormLabel>
-      {isLocked ? (
-        <InputGroup>
-          <Box
-            {...fixedInputProps}
-            pr="2.25rem"
-          >
-            {selectedProvider?.name ?? ""}
-          </Box>
-          <LockRightElement />
-        </InputGroup>
-      ) : (
-        <CustomSelect
-          options={options}
-          value={String(providerId ?? "")}
-          setValue={setProviderId}
-          isSearchable
-          placeholder="Select provider"
-          styleProps={fixedInputProps}
-        />
-      )}
+      <CustomSelect
+        options={options}
+        value={String(providerId ?? "")}
+        setValue={setProviderId}
+        isSearchable
+        isReadOnly={isLocked}
+        placeholder="Select provider"
+        styleProps={fixedInputProps}
+      />
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>
   );

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/TimeInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/TimeInput.jsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Flex,
   FormControl,
   FormErrorMessage,
@@ -9,7 +8,6 @@ import {
 } from "@chakra-ui/react";
 
 import { inputStyles } from "../tools/constants";
-import { formatTimeForDisplay } from "../tools/utils";
 
 export const TimeInput = ({
   startTime,
@@ -42,7 +40,6 @@ export const TimeInput = ({
     >
       <FormControl
         isRequired
-        isDisabled={isLocked}
         isInvalid={isInvalid}
       >
         <FormLabel
@@ -53,100 +50,48 @@ export const TimeInput = ({
           gap={2}
           minW={0}
         >
-          {isLocked ? (
-            <>
-              <InputGroup
-                flex="1"
-                minW={0}
-              >
-                <Box
-                  w="100%"
-                  border="1px"
-                  borderColor="gray.300"
-                  borderRadius="6px"
-                  px={3}
-                  py={2}
-                  fontSize="14px"
-                  bg="gray.50"
-                  color="gray.500"
-                >
-                  {formatTimeForDisplay(startTime)}
-                </Box>
-              </InputGroup>
-              <InputGroup
-                flex="1"
-                minW={0}
-              >
-                <Box
-                  w="100%"
-                  border="1px"
-                  borderColor="gray.300"
-                  borderRadius="6px"
-                  px={3}
-                  py={2}
-                  bg="gray.50"
-                  color="gray.500"
-                >
-                  {formatTimeForDisplay(endTime)}
-                </Box>
-              </InputGroup>
-            </>
-          ) : (
-            <>
-              <InputGroup
-                flex="1"
-                minW={0}
-              >
-                <Input
-                  fontSize="14px"
-                  size="md"
-                  type="time"
-                  px={3}
-                  {...inputStyles}
-                  w="100%"
-                  sx={{
-                    "&::-webkit-calendar-picker-indicator": {
-                      display: "none",
-                    },
-                    "&::-webkit-clear-button": {
-                      display: "none",
-                    },
-                    "&::-webkit-inner-spin-button": {
-                      display: "none",
-                    },
-                  }}
-                  value={startTime ?? ""}
-                  onChange={(e) => handleStartTimeChange(e.target.value)}
-                />
-              </InputGroup>
-              <InputGroup
-                flex="1"
-                minW={0}
-              >
-                <Input
-                  fontSize="14px"
-                  type="time"
-                  px={3}
-                  {...inputStyles}
-                  w="100%"
-                  sx={{
-                    "&::-webkit-calendar-picker-indicator": {
-                      display: "none",
-                    },
-                    "&::-webkit-clear-button": {
-                      display: "none",
-                    },
-                    "&::-webkit-inner-spin-button": {
-                      display: "none",
-                    },
-                  }}
-                  min={startTime || undefined}
-                  value={endTime ?? ""}
-                  onChange={(e) => handleEndTimeChange(e.target.value)}
-                />
-              </InputGroup>
-            </>
-          )}
+          <InputGroup
+            flex="1"
+            minW={0}
+          >
+            <Input
+              fontSize="14px"
+              size="md"
+              type="time"
+              px={3}
+              {...inputStyles}
+              w="100%"
+              sx={{
+                "&::-webkit-calendar-picker-indicator": { display: "none" },
+                "&::-webkit-clear-button": { display: "none" },
+                "&::-webkit-inner-spin-button": { display: "none" },
+              }}
+              readOnly={isLocked}
+              value={startTime ?? ""}
+              onChange={(e) => handleStartTimeChange(e.target.value)}
+            />
+          </InputGroup>
+          <InputGroup
+            flex="1"
+            minW={0}
+          >
+            <Input
+              fontSize="14px"
+              type="time"
+              px={3}
+              {...inputStyles}
+              w="100%"
+              sx={{
+                "&::-webkit-calendar-picker-indicator": { display: "none" },
+                "&::-webkit-clear-button": { display: "none" },
+                "&::-webkit-inner-spin-button": { display: "none" },
+              }}
+              readOnly={isLocked}
+              min={startTime || undefined}
+              value={endTime ?? ""}
+              onChange={(e) => handleEndTimeChange(e.target.value)}
+            />
+          </InputGroup>
         </Flex>
         <FormErrorMessage>Required</FormErrorMessage>
       </FormControl>

--- a/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
+++ b/client/src/components/quota-tracking/quota-drawer/form-fields/TypeInput.jsx
@@ -1,16 +1,14 @@
-import { Box, FormControl, FormErrorMessage, FormLabel, InputGroup } from "@chakra-ui/react";
+import { FormControl, FormErrorMessage, FormLabel } from "@chakra-ui/react";
 
 import CustomSelect from "@/components/common/CustomSelect";
 
 import { TYPE_OPTIONS } from "../tools/constants";
-import { LockRightElement } from "../tools/shared";
 
 export const TypeInput = ({ type, setType, isLocked, isInvalid }) => {
   return (
     <FormControl
       isRequired
       w="43%"
-      isDisabled={isLocked}
       isInvalid={isInvalid}
     >
       <FormLabel
@@ -19,31 +17,13 @@ export const TypeInput = ({ type, setType, isLocked, isInvalid }) => {
       >
         Type
       </FormLabel>
-      {isLocked ? (
-        <InputGroup>
-          <Box
-            w="100%"
-            border="1px"
-            borderColor="gray.300"
-            borderRadius="6px"
-            px={3}
-            py={2}
-            pr="2.25rem"
-            bg="gray.50"
-            color="gray.500"
-          >
-            {TYPE_OPTIONS.find((o) => o.value === type)?.label ?? type}
-          </Box>
-          <LockRightElement />
-        </InputGroup>
-      ) : (
-        <CustomSelect
-          options={TYPE_OPTIONS}
-          value={type ?? ""}
-          setValue={setType}
-          styleProps={isInvalid ? { border: "1px solid #FC8181" } : {}}
-        />
-      )}
+      <CustomSelect
+        options={TYPE_OPTIONS}
+        value={type ?? ""}
+        setValue={setType}
+        isReadOnly={isLocked}
+        styleProps={isInvalid ? { border: "1px solid #FC8181" } : {}}
+      />
       <FormErrorMessage>Required</FormErrorMessage>
     </FormControl>
   );


### PR DESCRIPTION
## Description
no more lock icons #wehatelockicons
small fix - added scrollbar so you can see all the info while isLocked is true (confirmation flow)

## Screenshots/Media
<img width="555" height="977" alt="image" src="https://github.com/user-attachments/assets/8330dc25-b0bb-429c-a1e7-d23102b5ac23" />

## Issues
Closes #249 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced lock icons in the Quota Drawer with read-only inputs to simplify the confirmation flow and align styling with the provider drawer. Fulfills Linear #249 and adds scrolling so all content is visible when locked.

- **Refactors**
  - Added `isReadOnly` support to `CalendarCard` and `CustomSelect`; hide chevrons and disable interactions when read-only.
  - Switched form fields (Date, Time, Type, Provider, Location, Notes) from disabled/locked UI to read-only inputs; removed lock elements and static display boxes.
  - Unified input styling while preserving validation states.

- **Bug Fixes**
  - Enabled drawer body scrolling in the confirmation (locked) state to avoid hidden content.
  - Guarded menu/open handlers to prevent interaction when locked.

<sup>Written for commit abc39251f2a5ac59a6e9a1f4b02c7062d66cefa7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

