### PR TITLE
251 add red asterisk next to provider input label

### DIFF
--- a/client/src/components/provider-directory/ProviderDrawer.jsx
+++ b/client/src/components/provider-directory/ProviderDrawer.jsx
@@ -188,7 +188,7 @@ const ProviderFormFields = ({
         alignItems="end"
       >
         <Box w="100%">
-          <FormLabel {...fixedLabelProps}>Provider Name</FormLabel>
+          <FormLabel {...fixedLabelProps}>Provider Name <Text as="span" color="red.500">*</Text></FormLabel>
           <Flex gap={2}>
             <FormControl
               isRequired


### PR DESCRIPTION
## Description
difficulty of a lc hard - never doing sprints like this again

## Screenshots/Media
<img width="262" height="92" alt="image" src="https://github.com/user-attachments/assets/94434a0e-dd49-4779-98ba-e50abb6d1ea2" />

## Issues
Closes #251 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a red asterisk to the Provider Name label to clearly indicate the field is required, improving form clarity. Aligns with the requirement in #251.

<sup>Written for commit 7c2620e2f2f1ef3a8d2335cb13b9ec5e256c33e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

