### PR TITLE
fix: frontend error being thrown in toast

### DIFF
--- a/client/src/components/provider-directory/ProviderDrawer.jsx
+++ b/client/src/components/provider-directory/ProviderDrawer.jsx
@@ -488,7 +488,7 @@ const ProviderDrawer = ({
 
     try {
       if (activeMode === "create") {
-        await createProvider(buildPayload(formValuesAfterTagDeletes));
+        await createProvider(buildPayload());
         toast({
           position: "top-right",
           duration: 5000,


### PR DESCRIPTION
## Description

"formValuesAfterTagDeletes is not defined" being thrown in a frontend toast when trying to create a provider. Fix was removing a leftover variable from merging in #149 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a toast error ("formValuesAfterTagDeletes is not defined") when creating a provider. We now call `buildPayload()` without the removed variable so creation works without errors.

<sup>Written for commit 08a5069c8807c08cffe28a9fa1118d883b05857d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

