### PR TITLE
implement multi send

### DIFF
--- a/server/utils/emailService.js
+++ b/server/utils/emailService.js
@@ -33,15 +33,24 @@ export async function notifyCcmNewUserRequest(name, email) {
       </div>
     `;
 
-    // Query for CCM's email address
-    const rows = await db.query(`SELECT email FROM users WHERE role = 'ccm'`);
-    // Validate email
-    if (!rows || !rows.length) throw new Error("Cannot find ccm.");
-    const ccmEmail = rows[0].email;
+    const masterRows = await db.query(`SELECT email FROM users WHERE role = 'master'`);
+    const ccmRows = await db.query(`SELECT email FROM users WHERE role = 'ccm'`);
+
+    if ((!masterRows || !masterRows.length) && (!ccmRows || !ccmRows.length)) {
+      throw new Error("Cannot find any master or ccm users.");
+    }
+
+    if (masterRows.length > 1) {
+      throw new Error(`Expected at most one master user, found ${masterRows.length}.`);
+    }
+
+    const masterEmails = masterRows.map((r) => r.email).join(", ");
+    const ccmEmails = ccmRows.map((r) => r.email).join(", ");
 
     await transporter.sendMail({
       from: `"Admin" <${process.env.EMAIL_USER}>`,
-      to: ccmEmail,
+      to: masterEmails || undefined,
+      cc: ccmEmails || undefined,
       subject: "New User Request",
       text: `New user request from ${sanitizedName} (${sanitizedEmail})`,
       html: emailMessage,


### PR DESCRIPTION
## Description
Auth emails from CLC automated account to the master role and CC CCMs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send new user request emails to the master role and CC all CCMs instead of emailing a single CCM. Adds guard rails to require at least one recipient and to error if multiple masters are found.

<sup>Written for commit 8a77507f1a1f48327e18054e2bc7a186d1145df2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/clchc/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

